### PR TITLE
update ch9 event group

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -875,7 +875,7 @@ void SocketRxTask( void *pvParameters )
 
 An event group can be used to create a synchronization point:
 
-- Each task that must participate in the synchronization is assigned an
+- Each task that must participate in the synchronization is assigned a
   unique event bit within the event group.
 
 - Each task sets its own event bit when it reaches the synchronization


### PR DESCRIPTION
This PR updates Chapter 9 Event Group (original chapter 8) of the FreeRTOS Kernel Book
- Replace configUSE_16_BIT_TICKS with configTICK_TYPE_WIDTH_IN_BITS.
- Add xEventGroupGetStaticBuffer() function description in 9.3.5.