### PR TITLE
Remove version control

### DIFF
--- a/ch02.md
+++ b/ch02.md
@@ -218,9 +218,6 @@ FreeRTOS/Source/portable/\[*compiler*\]/\[*architecture*\] directory.
 
 As described in Chapter 3, Heap Memory Management, FreeRTOS also
 considers heap memory allocation to be part of the portable layer. If
-you are using a version of FreeRTOS older than V9.0.0, then you must
-include a heap memory allocation scheme in your project. FreeRTOS V9.0.0
-introduced the `configSUPPORT_DYNAMIC_ALLOCATION` configuration option. If
 `configSUPPORT_DYNAMIC_ALLOCATION` is set to 0, then do not include a heap
 memory allocation scheme in your project.
 
@@ -456,13 +453,10 @@ procedure to create a new project:
 *Table 1. FreeRTOS source files to include in the project*
 
 >**Note on heap**
-If you are using a version of FreeRTOS older than V9.0.0, you must
-include a heap memory allocation scheme in your project, either one of
-the heap\_*n*.c files, or one provided by yourself. FreeRTOS V9.0.0
-introduced the `configSUPPORT_DYNAMIC_ALLOCATION` configuration option. If
-`configSUPPORT_DYNAMIC_ALLOCATION` is 0 then do not include a heap memory
-allocation scheme in your project. Refer to Chapter 3, Heap Memory
-Management, for more information.
+If `configSUPPORT_DYNAMIC_ALLOCATION` is 0 then do not include a heap memory
+allocation scheme in your project. Else include a heap memory allocation scheme 
+in your project, either one of the heap\_*n*.c files, or one provided by 
+yourself. Refer to Chapter 3, Heap Memory Management, for more information.
 
 
 ## 2.5 Data Types and Coding Style Guide

--- a/ch06.md
+++ b/ch06.md
@@ -384,7 +384,7 @@ sent, not 10 ticks after the command was processed by the daemon task.
 
 ### 6.5.1 The xTimerCreate() API Function
 
-FreeRTOS V9.0.0 also includes the `xTimerCreateStatic()` function, which
+FreeRTOS also includes the `xTimerCreateStatic()` function, which
 allocates the memory required to create a timer statically at compile
 time: A software timer must be explicitly created before it can be used.
 

--- a/ch07.md
+++ b/ch07.md
@@ -442,7 +442,7 @@ back—such as the scenarios described in Chapter 8, Resource Management.
 
 ### 7.4.1 The xSemaphoreCreateBinary() API Function
 
-FreeRTOS V9.0.0 also includes the `xSemaphoreCreateBinaryStatic()`
+FreeRTOS also includes the `xSemaphoreCreateBinaryStatic()`
 function, which allocates the memory required to create a binary
 semaphore statically at compile time: Handles to all the various types
 of FreeRTOS semaphore are stored in a variable of type
@@ -985,7 +985,7 @@ Counting semaphores are typically used for two things:
 
 ### 7.5.1 The xSemaphoreCreateCounting() API Function
 
-FreeRTOS V9.0.0 also includes the `xSemaphoreCreateCountingStatic()`
+FreeRTOS also includes the `xSemaphoreCreateCountingStatic()`
 function, which allocates the memory required to create a counting
 semaphore statically at compile time: Handles to all the various types
 of FreeRTOS semaphore are stored in a variable of type `SemaphoreHandle_t`.

--- a/ch08.md
+++ b/ch08.md
@@ -471,7 +471,7 @@ the mutex holder.
 
 ### 8.3.1 The xSemaphoreCreateMutex() API Function
 
-FreeRTOS V9.0.0 also includes the `xSemaphoreCreateMutexStatic()`
+FreeRTOS also includes the `xSemaphoreCreateMutexStatic()`
 function, which allocates the memory required to create a mutex
 statically at compile time: A mutex is a type of semaphore. Handles to
 all the various types of FreeRTOS semaphore are stored in a variable of

--- a/ch09.md
+++ b/ch09.md
@@ -163,7 +163,7 @@ time.
 
 ### 9.3.1 The xEventGroupCreate() API Function
 
-FreeRTOS V9.0.0 also includes the `xEventGroupCreateStatic()` function,
+FreeRTOS also includes the `xEventGroupCreateStatic()` function,
 which allocates the memory required to create an event group statically
 at compile time: An event group must be explicitly created before it can
 be used.


### PR DESCRIPTION
This PR removes mentions of ```FreeRTOS V9.0.0``` in various chapters, because version controlling will be handled separately in a separate format.