### PR TITLE
Fix formatting in examples

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -1102,7 +1102,9 @@ static void prvPrintTask( void *pvParameters )
            to the string to the gatekeeper task via a queue. The queue is 
            created before the scheduler is started so will already exist by the
            time this task executes for the first time. A block time is not 
-           specified because there should always be space in the queue. */
+           specified because there should always be space in the queue. 
+           Posts to the queue that are not successful may pass unnoticed as the 
+           return value of the queue send function is not checked. */
         xQueueSendToBack( xPrintQueue, &( pcStringsToPrint[ iIndexToString ]), 0 );
 
         /* Wait a pseudo random time. Note that rand() is not necessarily

--- a/examples/Win32-simulator-MSVC/Examples/Example001/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example001/main.c
@@ -61,7 +61,7 @@
 #include "supporting_functions.h"
 
 /* Used as a loop counter to create a very crude delay. */
-#define mainDELAY_LOOP_COUNT		( 0xffffff )
+#define mainDELAY_LOOP_COUNT        ( 0xffffff )
 
 /* The task functions. */
 void vTask1( void *pvParameters );
@@ -71,70 +71,76 @@ void vTask2( void *pvParameters );
 
 int main( void )
 {
-	/* Create one of the two tasks. */
-	xTaskCreate(	vTask1,		/* Pointer to the function that implements the task. */
-					"Task 1",	/* Text name for the task.  This is to facilitate debugging only. */
-					1000,		/* Stack depth - most small microcontrollers will use much less stack than this. */
-					NULL,		/* We are not using the task parameter. */
-					1,			/* This task will run at priority 1. */
-					NULL );		/* We are not using the task handle. */
+    /* Create one of the two tasks. */
+    xTaskCreate(    vTask1,        /* Pointer to the function that implements the task. */
+                    "Task 1",    /* Text name for the task.  This is to facilitate debugging only. */
+                    1000,        /* Stack depth - most small microcontrollers will use much less stack than this. */
+                    NULL,        /* We are not using the task parameter. */
+                    1,            /* This task will run at priority 1. */
+                    NULL );        /* We are not using the task handle. */
 
-	/* Create the other task in exactly the same way. */
-	xTaskCreate( vTask2, "Task 2", 1000, NULL, 1, NULL );
+    /* Create the other task in exactly the same way. */
+    xTaskCreate( vTask2, "Task 2", 1000, NULL, 1, NULL );
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();	
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();    
 
-	/* The following line should never be reached because vTaskStartScheduler() 
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler() 
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vTask1( void *pvParameters )
 {
-const char *pcTaskName = "Task 1 is running\r\n";
-volatile uint32_t ul;
+    const char *pcTaskName = "Task 1 is running\r\n";
+    volatile uint32_t ul;
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( pcTaskName );
+    /* Remove compiler warning about unused parameter. */
+    ( void ) pvParameters;
 
-		/* Delay for a period. */
-		for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
-		{
-			/* This loop is just a very crude delay implementation.  There is
-			nothing to do in here.  Later exercises will replace this crude
-			loop with a proper delay/sleep function. */
-		}
-	}
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( pcTaskName );
+
+        /* Delay for a period. */
+        for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
+        {
+            /* This loop is just a very crude delay implementation.  There is
+            nothing to do in here.  Later exercises will replace this crude
+            loop with a proper delay/sleep function. */
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vTask2( void *pvParameters )
 {
-const char *pcTaskName = "Task 2 is running\r\n";
-volatile uint32_t ul;
+    const char *pcTaskName = "Task 2 is running\r\n";
+    volatile uint32_t ul;
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( pcTaskName );
+    /* Remove compiler warning about unused parameter. */
+    ( void ) pvParameters;
 
-		/* Delay for a period. */
-		for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
-		{
-			/* This loop is just a very crude delay implementation.  There is
-			nothing to do in here.  Later exercises will replace this crude
-			loop with a proper delay/sleep function. */
-		}
-	}
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( pcTaskName );
+
+        /* Delay for a period. */
+        for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
+        {
+            /* This loop is just a very crude delay implementation.  There is
+            nothing to do in here.  Later exercises will replace this crude
+            loop with a proper delay/sleep function. */
+        }
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example002/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example002/main.c
@@ -61,7 +61,7 @@
 #include "supporting_functions.h"
 
 /* Used as a loop counter to create a very crude delay. */
-#define mainDELAY_LOOP_COUNT		( 0xffffff )
+#define mainDELAY_LOOP_COUNT        ( 0xffffff )
 
 /* The task function. */
 void vTaskFunction( void *pvParameters );
@@ -76,54 +76,54 @@ const char *pcTextForTask2 = "Task 2 is running\r\n";
 
 int main( void )
 {
-	/* Create one of the two tasks. */
-	xTaskCreate(	vTaskFunction,			/* Pointer to the function that implements the task. */
-					"Task 1",				/* Text name for the task.  This is to facilitate debugging only. */
-					1000,					/* Stack depth - most small microcontrollers will use much less stack than this. */
-					(void*)pcTextForTask1,	/* Pass the text to be printed in as the task parameter. */
-					1,						/* This task will run at priority 1. */
-					NULL );					/* We are not using the task handle. */
+    /* Create one of the two tasks. */
+    xTaskCreate(    vTaskFunction,            /* Pointer to the function that implements the task. */
+                    "Task 1",                /* Text name for the task.  This is to facilitate debugging only. */
+                    1000,                    /* Stack depth - most small microcontrollers will use much less stack than this. */
+                    (void*)pcTextForTask1,    /* Pass the text to be printed in as the task parameter. */
+                    1,                        /* This task will run at priority 1. */
+                    NULL );                    /* We are not using the task handle. */
 
-	/* Create the other task in exactly the same way.  Note this time that we
-	are creating the SAME task, but passing in a different parameter.  We are
-	creating two instances of a single task implementation. */
-	xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 1, NULL );
+    /* Create the other task in exactly the same way.  Note this time that we
+    are creating the SAME task, but passing in a different parameter.  We are
+    creating two instances of a single task implementation. */
+    xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 1, NULL );
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();	
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();    
 
-	/* The following line should never be reached because vTaskStartScheduler() 
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler() 
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vTaskFunction( void *pvParameters )
 {
-char *pcTaskName;
-volatile uint32_t ul;
+    char *pcTaskName;
+    volatile uint32_t ul;
 
-	/* The string to print out is passed in via the parameter.  Cast this to a
-	character pointer. */
-	pcTaskName = ( char * ) pvParameters;
+    /* The string to print out is passed in via the parameter.  Cast this to a
+    character pointer. */
+    pcTaskName = ( char * ) pvParameters;
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( pcTaskName );
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( pcTaskName );
 
-		/* Delay for a period. */
-		for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
-		{
-			/* This loop is just a very crude delay implementation.  There is
-			nothing to do in here.  Later exercises will replace this crude
-			loop with a proper delay/sleep function. */
-		}
-	}
+        /* Delay for a period. */
+        for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
+        {
+            /* This loop is just a very crude delay implementation.  There is
+            nothing to do in here.  Later exercises will replace this crude
+            loop with a proper delay/sleep function. */
+        }
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example003/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example003/main.c
@@ -61,7 +61,7 @@
 #include "supporting_functions.h"
 
 /* Used as a loop counter to create a very crude delay. */
-#define mainDELAY_LOOP_COUNT		( 0xffffff )
+#define mainDELAY_LOOP_COUNT        ( 0xffffff )
 
 /* The task function. */
 void vTaskFunction( void *pvParameters );
@@ -76,48 +76,48 @@ const char *pcTextForTask2 = "Task 2 is running\r\n";
 
 int main( void )
 {
-	/* Create the first task at priority 1... */
-	xTaskCreate( vTaskFunction, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
+    /* Create the first task at priority 1... */
+    xTaskCreate( vTaskFunction, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
 
-	/* ... and the second task at priority 2.  The priority is the second to
-	last parameter. */
-	xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 2, NULL );
+    /* ... and the second task at priority 2.  The priority is the second to
+    last parameter. */
+    xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 2, NULL );
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();	
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();    
 
-	/* The following line should never be reached because vTaskStartScheduler() 
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler() 
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vTaskFunction( void *pvParameters )
 {
-char *pcTaskName;
-volatile uint32_t ul;
+    char *pcTaskName;
+    volatile uint32_t ul;
 
-	/* The string to print out is passed in via the parameter.  Cast this to a
-	character pointer. */
-	pcTaskName = ( char * ) pvParameters;
+    /* The string to print out is passed in via the parameter.  Cast this to a
+    character pointer. */
+    pcTaskName = ( char * ) pvParameters;
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( pcTaskName );
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( pcTaskName );
 
-		/* Delay for a period. */
-		for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
-		{
-			/* This loop is just a very crude delay implementation.  There is
-			nothing to do in here.  Later exercises will replace this crude
-			loop with a proper delay/sleep function. */
-		}
-	}
+        /* Delay for a period. */
+        for( ul = 0; ul < mainDELAY_LOOP_COUNT; ul++ )
+        {
+            /* This loop is just a very crude delay implementation.  There is
+            nothing to do in here.  Later exercises will replace this crude
+            loop with a proper delay/sleep function. */
+        }
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example004/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example004/main.c
@@ -73,48 +73,48 @@ const char *pcTextForTask2 = "Task 2 is running\r\n";
 
 int main( void )
 {
-	/* Create the first task at priority 1... */
-	xTaskCreate( vTaskFunction, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
+    /* Create the first task at priority 1... */
+    xTaskCreate( vTaskFunction, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
 
-	/* ... and the second task at priority 2.  The priority is the second to
-	last parameter. */
-	xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 2, NULL );
+    /* ... and the second task at priority 2.  The priority is the second to
+    last parameter. */
+    xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 2, NULL );
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vTaskFunction( void *pvParameters )
 {
-char *pcTaskName;
-const TickType_t xDelay250ms = pdMS_TO_TICKS( 250UL );
+    char *pcTaskName;
+    const TickType_t xDelay250ms = pdMS_TO_TICKS( 250UL );
 
-	/* The string to print out is passed in via the parameter.  Cast this to a
-	character pointer. */
-	pcTaskName = ( char * ) pvParameters;
+    /* The string to print out is passed in via the parameter.  Cast this to a
+    character pointer. */
+    pcTaskName = ( char * ) pvParameters;
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( pcTaskName );
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( pcTaskName );
 
-		/* Delay for a period.  This time a call to vTaskDelay() is used which
-		places the task into the Blocked state until the delay period has
-		expired.  The parameter takes a time specified in 'ticks', and the
-		pdMS_TO_TICKS() macro is used (where the xDelay250ms constant is
-		declared) to convert 250 milliseconds into an equivalent time in
-		ticks. */
-		vTaskDelay( xDelay250ms );
-	}
+        /* Delay for a period.  This time a call to vTaskDelay() is used which
+        places the task into the Blocked state until the delay period has
+        expired.  The parameter takes a time specified in 'ticks', and the
+        pdMS_TO_TICKS() macro is used (where the xDelay250ms constant is
+        declared) to convert 250 milliseconds into an equivalent time in
+        ticks. */
+        vTaskDelay( xDelay250ms );
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example005/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example005/main.c
@@ -73,54 +73,54 @@ const char *pcTextForTask2 = "Task 2 is running\r\n";
 
 int main( void )
 {
-	/* Create the first task at priority 1... */
-	xTaskCreate( vTaskFunction, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
+    /* Create the first task at priority 1... */
+    xTaskCreate( vTaskFunction, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
 
-	/* ... and the second task at priority 2.  The priority is the second to
-	last parameter. */
-	xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 2, NULL );
+    /* ... and the second task at priority 2.  The priority is the second to
+    last parameter. */
+    xTaskCreate( vTaskFunction, "Task 2", 1000, (void*)pcTextForTask2, 2, NULL );
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vTaskFunction( void *pvParameters )
 {
-char *pcTaskName;
-TickType_t xLastWakeTime;
-const TickType_t xDelay250ms = pdMS_TO_TICKS( 250UL );
+    char *pcTaskName;
+    TickType_t xLastWakeTime;
+    const TickType_t xDelay250ms = pdMS_TO_TICKS( 250UL );
 
-	/* The string to print out is passed in via the parameter.  Cast this to a
-	character pointer. */
-	pcTaskName = ( char * ) pvParameters;
+    /* The string to print out is passed in via the parameter.  Cast this to a
+    character pointer. */
+    pcTaskName = ( char * ) pvParameters;
 
-	/* The xLastWakeTime variable needs to be initialized with the current tick
-	count.  Note that this is the only time we access this variable.  From this
-	point on xLastWakeTime is managed automatically by the vTaskDelayUntil()
-	API function. */
-	xLastWakeTime = xTaskGetTickCount();
+    /* The xLastWakeTime variable needs to be initialized with the current tick
+    count.  Note that this is the only time we access this variable.  From this
+    point on xLastWakeTime is managed automatically by the vTaskDelayUntil()
+    API function. */
+    xLastWakeTime = xTaskGetTickCount();
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( pcTaskName );
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( pcTaskName );
 
-		/* We want this task to execute exactly every 250 milliseconds.  As per
-		the vTaskDelay() function, time is measured in ticks, and the
-		pdMS_TO_TICKS() macro is used to convert this to milliseconds.
-		xLastWakeTime is automatically updated within vTaskDelayUntil() so does not
-		have to be updated by this task code. */
-		vTaskDelayUntil( &xLastWakeTime, xDelay250ms );
-	}
+        /* We want this task to execute exactly every 250 milliseconds.  As per
+        the vTaskDelay() function, time is measured in ticks, and the
+        pdMS_TO_TICKS() macro is used to convert this to milliseconds.
+        xLastWakeTime is automatically updated within xTaskDelayUntil() so does not
+        have to be updated by this task code. */
+        xTaskDelayUntil( &xLastWakeTime, xDelay250ms );
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example006/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example006/main.c
@@ -1,4 +1,4 @@
-/*
+/*MODIFIED
     FreeRTOS V9.0.0 - Copyright (C) 2016 Real Time Engineers Ltd.
     All rights reserved
 
@@ -75,63 +75,63 @@ const char *pcTextForPeriodicTask = "Periodic task is running\r\n";
 
 int main( void )
 {
-	/* Create two instances of the continuous processing task, both at priority	1. */
-	xTaskCreate( vContinuousProcessingTask, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
-	xTaskCreate( vContinuousProcessingTask, "Task 2", 1000, (void*)pcTextForTask2, 1, NULL );
+    /* Create two instances of the continuous processing task, both at priority    1. */
+    xTaskCreate( vContinuousProcessingTask, "Task 1", 1000, (void*)pcTextForTask1, 1, NULL );
+    xTaskCreate( vContinuousProcessingTask, "Task 2", 1000, (void*)pcTextForTask2, 1, NULL );
 
-	/* Create one instance of the periodic task at priority 2. */
-	xTaskCreate( vPeriodicTask, "Task 3", 1000, (void*)pcTextForPeriodicTask, 2, NULL );
+    /* Create one instance of the periodic task at priority 2. */
+    xTaskCreate( vPeriodicTask, "Task 3", 1000, (void*)pcTextForPeriodicTask, 2, NULL );
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vContinuousProcessingTask( void *pvParameters )
 {
-char *pcTaskName;
+    char *pcTaskName;
 
-	/* The string to print out is passed in via the parameter.  Cast this to a
-	character pointer. */
-	pcTaskName = ( char * ) pvParameters;
+    /* The string to print out is passed in via the parameter.  Cast this to a
+    character pointer. */
+    pcTaskName = ( char * ) pvParameters;
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task.  This task just does this repeatedly
-		without ever blocking or delaying. */
-		vPrintString( pcTaskName );
-	}
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task.  This task just does this repeatedly
+        without ever blocking or delaying. */
+        vPrintString( pcTaskName );
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPeriodicTask( void *pvParameters )
 {
-TickType_t xLastWakeTime;
-const TickType_t xDelay5ms = pdMS_TO_TICKS( 3UL );
+    TickType_t xLastWakeTime;
+    const TickType_t xDelay5ms = pdMS_TO_TICKS( 3UL );
 
-	/* The xLastWakeTime variable needs to be initialized with the current tick
-	count.  Note that this is the only time we access this variable.  From this
-	point on xLastWakeTime is managed automatically by the vTaskDelayUntil()
-	API function. */
-	xLastWakeTime = xTaskGetTickCount();
+    /* The xLastWakeTime variable needs to be initialized with the current tick
+    count.  Note that this is the only time we access this variable.  From this
+    point on xLastWakeTime is managed automatically by the vTaskDelayUntil()
+    API function. */
+    xLastWakeTime = xTaskGetTickCount();
 
-	/* As per most tasks, this task is implemented in an infinite loop. */
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( "Periodic task is running\r\n" );
+    /* As per most tasks, this task is implemented in an infinite loop. */
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( "Periodic task is running\r\n" );
 
-		/* We want this task to execute exactly every 10 milliseconds. */
-		vTaskDelayUntil( &xLastWakeTime, xDelay5ms );
-	}
+        /* We want this task to execute exactly every 10 milliseconds. */
+        xTaskDelayUntil( &xLastWakeTime, xDelay5ms );
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example007/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example007/main.c
@@ -97,8 +97,8 @@ int main( void )
 
 void vTaskFunction( void *pvParameters )
 {
-char *pcTaskName;
-const TickType_t xDelay250ms = pdMS_TO_TICKS( 250UL );
+    char *pcTaskName;
+    const TickType_t xDelay250ms = pdMS_TO_TICKS( 250UL );
 
 	/* The string to print out is passed in via the parameter.  Cast this to a
 	character pointer. */

--- a/examples/Win32-simulator-MSVC/Examples/Example008/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example008/main.c
@@ -71,89 +71,89 @@ TaskHandle_t xTask2Handle;
 
 int main( void )
 {
-	/* Create the first task at priority 2.  This time the task parameter is
-	not used and is set to NULL.  The task handle is also not used so likewise 
-	is also set to NULL. */
-	xTaskCreate( vTask1, "Task 1", 1000, NULL, 2, NULL );
+    /* Create the first task at priority 2.  This time the task parameter is
+    not used and is set to NULL.  The task handle is also not used so likewise 
+    is also set to NULL. */
+    xTaskCreate( vTask1, "Task 1", 1000, NULL, 2, NULL );
           /* The task is created at priority 2 ^. */
 
-	/* Create the second task at priority 1 - which is lower than the priority
-	given to Task1.  Again the task parameter is not used so is set to NULL -
-	BUT this time we want to obtain a handle to the task so pass in the address
-	of the xTask2Handle variable. */
-	xTaskCreate( vTask2, "Task 2", 1000, NULL, 1, &xTask2Handle );
+    /* Create the second task at priority 1 - which is lower than the priority
+    given to Task1.  Again the task parameter is not used so is set to NULL -
+    BUT this time we want to obtain a handle to the task so pass in the address
+    of the xTask2Handle variable. */
+    xTaskCreate( vTask2, "Task 2", 1000, NULL, 1, &xTask2Handle );
          /* The task handle is the last parameter ^^^^^^^^^^^^^ */
 
-	/* Start the scheduler to start the tasks executing. */
-	vTaskStartScheduler();	
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler() 
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler() 
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vTask1( void *pvParameters )
 {
-UBaseType_t uxPriority;
+    UBaseType_t uxPriority;
 
-	/* This task will always run before Task2 as it has the higher priority.
-	Neither Task1 nor Task2 ever block so both will always be in either the
-	Running or the Ready state.
+    /* This task will always run before Task2 as it has the higher priority.
+    Neither Task1 nor Task2 ever block so both will always be in either the
+    Running or the Ready state.
 
-	Query the priority at which this task is running - passing in NULL means
-	"return our own priority". */
-	uxPriority = uxTaskPriorityGet( NULL );
+    Query the priority at which this task is running - passing in NULL means
+    "return our own priority". */
+    uxPriority = uxTaskPriorityGet( NULL );
 
-	for( ;; )
-	{
-		/* Print out the name of this task. */
-		vPrintString( "Task1 is running\r\n" );
+    for( ;; )
+    {
+        /* Print out the name of this task. */
+        vPrintString( "Task1 is running\r\n" );
 
-		/* Setting the Task2 priority above the Task1 priority will cause
-		Task2 to immediately start running (as then Task2 will have the higher 
-		priority of the    two created tasks). */
-		vPrintString( "About to raise the Task2 priority\r\n" );
-		vTaskPrioritySet( xTask2Handle, ( uxPriority + 1 ) );
+        /* Setting the Task2 priority above the Task1 priority will cause
+        Task2 to immediately start running (as then Task2 will have the higher 
+        priority of the    two created tasks). */
+        vPrintString( "About to raise the Task2 priority\r\n" );
+        vTaskPrioritySet( xTask2Handle, ( uxPriority + 1 ) );
 
-		/* Task1 will only run when it has a priority higher than Task2.
-		Therefore, for this task to reach this point Task2 must already have
-		executed and set its priority back down to 0. */
-	}
+        /* Task1 will only run when it has a priority higher than Task2.
+        Therefore, for this task to reach this point Task2 must already have
+        executed and set its priority back down to 0. */
+    }
 }
 
 /*-----------------------------------------------------------*/
 
 void vTask2( void *pvParameters )
 {
-UBaseType_t uxPriority;
+    UBaseType_t uxPriority;
 
-	/* Task1 will always run before this task as Task1 has the higher priority.
-	Neither Task1 nor Task2 ever block so will always be in either the
-	Running or the Ready state.
+    /* Task1 will always run before this task as Task1 has the higher priority.
+    Neither Task1 nor Task2 ever block so will always be in either the
+    Running or the Ready state.
 
-	Query the priority at which this task is running - passing in NULL means
-	"return our own priority". */
-	uxPriority = uxTaskPriorityGet( NULL );
+    Query the priority at which this task is running - passing in NULL means
+    "return our own priority". */
+    uxPriority = uxTaskPriorityGet( NULL );
 
-	for( ;; )
-	{
-		/* For this task to reach this point Task1 must have already run and
-		set the priority of this task higher than its own.
+    for( ;; )
+    {
+        /* For this task to reach this point Task1 must have already run and
+        set the priority of this task higher than its own.
 
-		Print out the name of this task. */
-		vPrintString( "Task2 is running\r\n" );
+        Print out the name of this task. */
+        vPrintString( "Task2 is running\r\n" );
 
-		/* Set our priority back down to its original value.  Passing in NULL
-		as the task handle means "change our own priority".  Setting the
-		priority below that of Task1 will cause Task1 to immediately start
-		running again. */
-		vPrintString( "About to lower the Task2 priority\r\n" );
-		vTaskPrioritySet( NULL, ( uxPriority - 2 ) );
-	}
+        /* Set our priority back down to its original value.  Passing in NULL
+        as the task handle means "change our own priority".  Setting the
+        priority below that of Task1 will cause Task1 to immediately start
+        running again. */
+        vPrintString( "About to lower the Task2 priority\r\n" );
+        vTaskPrioritySet( NULL, ( uxPriority - 2 ) );
+    }
 }
 /*-----------------------------------------------------------*/
 

--- a/examples/Win32-simulator-MSVC/Examples/Example009/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example009/main.c
@@ -91,7 +91,7 @@ int main( void )
 
 void vTask1( void *pvParameters )
 {
-const TickType_t xDelay100ms = pdMS_TO_TICKS( 100UL );
+    const TickType_t xDelay100ms = pdMS_TO_TICKS( 100UL );
 
 	for( ;; )
 	{

--- a/examples/Win32-simulator-MSVC/Examples/Example010/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example010/main.c
@@ -112,8 +112,8 @@ int main( void )
 
 static void vSenderTask( void *pvParameters )
 {
-int32_t lValueToSend;
-BaseType_t xStatus;
+	int32_t lValueToSend;
+	BaseType_t xStatus;
 
 	/* Two instances are created of this task so the value that is sent to the
 	queue is passed in via the task parameter rather than be hard coded.  This way
@@ -148,10 +148,10 @@ BaseType_t xStatus;
 
 static void vReceiverTask( void *pvParameters )
 {
-/* Declare the variable that will hold the values received from the queue. */
-int32_t lReceivedValue;
-BaseType_t xStatus;
-const TickType_t xTicksToWait = pdMS_TO_TICKS( 100UL );
+	/* Declare the variable that will hold the values received from the queue. */
+	int32_t lReceivedValue;
+	BaseType_t xStatus;
+	const TickType_t xTicksToWait = pdMS_TO_TICKS( 100UL );
 
 	/* This task is also defined within an infinite loop. */
 	for( ;; )

--- a/examples/Win32-simulator-MSVC/Examples/Example011/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example011/main.c
@@ -74,22 +74,22 @@ QueueHandle_t xQueue;
 
 typedef enum
 {
-	eSender1,
-	eSender2
+    eSender1,
+    eSender2
 } DataSource_t;
 
 /* Define the structure type that will be passed on the queue. */
 typedef struct
 {
-	uint8_t ucValue;
-	DataSource_t eDataSource;
+    uint8_t ucValue;
+    DataSource_t eDataSource;
 } Data_t;
 
 /* Declare two variables of type Data_t that will be passed on the queue. */
 static const Data_t xStructsToSend[ 2 ] =
 {
-	{ 100, eSender1 }, /* Used by Sender1. */
-	{ 200, eSender2 }  /* Used by Sender2. */
+    { 100, eSender1 }, /* Used by Sender1. */
+    { 200, eSender2 }  /* Used by Sender2. */
 };
 
 int main( void )
@@ -97,34 +97,34 @@ int main( void )
     /* The queue is created to hold a maximum of 3 structures of type Data_t. */
     xQueue = xQueueCreate( 3, sizeof( Data_t ) );
 
-	if( xQueue != NULL )
-	{
-		/* Create two instances of the task that will write to the queue.  The
-		parameter is used to pass the structure that the task should write to the
-		queue, so one task will continuously send xStructsToSend[ 0 ] to the queue
-		while the other task will continuously send xStructsToSend[ 1 ].  Both
-		tasks are created at priority 2, which is above the priority of the receiver. */
-		xTaskCreate( vSenderTask, "Sender1", 1000, ( void * ) &( xStructsToSend[ 0 ] ), 2, NULL );
-		xTaskCreate( vSenderTask, "Sender2", 1000, ( void * ) &( xStructsToSend[ 1 ] ), 2, NULL );
+    if( xQueue != NULL )
+    {
+        /* Create two instances of the task that will write to the queue.  The
+        parameter is used to pass the structure that the task should write to the
+        queue, so one task will continuously send xStructsToSend[ 0 ] to the queue
+        while the other task will continuously send xStructsToSend[ 1 ].  Both
+        tasks are created at priority 2, which is above the priority of the receiver. */
+        xTaskCreate( vSenderTask, "Sender1", 1000, ( void * ) &( xStructsToSend[ 0 ] ), 2, NULL );
+        xTaskCreate( vSenderTask, "Sender2", 1000, ( void * ) &( xStructsToSend[ 1 ] ), 2, NULL );
 
-		/* Create the task that will read from the queue.  The task is created with
-		priority 1, so below the priority of the sender tasks. */
-		xTaskCreate( vReceiverTask, "Receiver", 1000, NULL, 1, NULL );
+        /* Create the task that will read from the queue.  The task is created with
+        priority 1, so below the priority of the sender tasks. */
+        xTaskCreate( vReceiverTask, "Receiver", 1000, NULL, 1, NULL );
 
-		/* Start the scheduler so the created tasks start executing. */
-		vTaskStartScheduler();
-	}
-	else
-	{
-		/* The queue could not be created. */
-	}
+        /* Start the scheduler so the created tasks start executing. */
+        vTaskStartScheduler();
+    }
+    else
+    {
+        /* The queue could not be created. */
+    }
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -133,31 +133,31 @@ static void vSenderTask( void *pvParameters )
 BaseType_t xStatus;
 const TickType_t xTicksToWait = pdMS_TO_TICKS( 100UL );
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* The first parameter is the queue to which data is being sent.  The
-		queue was created before the scheduler was started, so before this task
-		started to execute.
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* The first parameter is the queue to which data is being sent.  The
+        queue was created before the scheduler was started, so before this task
+        started to execute.
 
-		The second parameter is the address of the structure being sent.  The
-		address is passed in as the task parameter.
+        The second parameter is the address of the structure being sent.  The
+        address is passed in as the task parameter.
 
-		The third parameter is the Block time - the time the task should be kept
-		in the Blocked state to wait for space to become available on the queue
-		should the queue already be full.  A block time is specified as the queue
-		will become full.  Items will only be removed from the queue when both
-		sending tasks are in the Blocked state.. */
-		xStatus = xQueueSendToBack( xQueue, pvParameters, xTicksToWait );
+        The third parameter is the Block time - the time the task should be kept
+        in the Blocked state to wait for space to become available on the queue
+        should the queue already be full.  A block time is specified as the queue
+        will become full.  Items will only be removed from the queue when both
+        sending tasks are in the Blocked state.. */
+        xStatus = xQueueSendToBack( xQueue, pvParameters, xTicksToWait );
 
-		if( xStatus != pdPASS )
-		{
-			/* We could not write to the queue because it was full - this must
-			be an error as the receiving task should make space in the queue
-			as soon as both sending tasks are in the Blocked state. */
-			vPrintString( "Could not send to the queue.\r\n" );
-		}
-	}
+        if( xStatus != pdPASS )
+        {
+            /* We could not write to the queue because it was full - this must
+            be an error as the receiving task should make space in the queue
+            as soon as both sending tasks are in the Blocked state. */
+            vPrintString( "Could not send to the queue.\r\n" );
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -167,51 +167,51 @@ static void vReceiverTask( void *pvParameters )
 Data_t xReceivedStructure;
 BaseType_t xStatus;
 
-	/* This task is also defined within an infinite loop. */
-	for( ;; )
-	{
-		/* As this task only runs when the sending tasks are in the Blocked state,
-		and the sending tasks only block when the queue is full, this task should
-		always find the queue to be full.  3 is the queue length. */
-		if( uxQueueMessagesWaiting( xQueue ) != 3 )
-		{
-			vPrintString( "Queue should have been full!\r\n" );
-		}
+    /* This task is also defined within an infinite loop. */
+    for( ;; )
+    {
+        /* As this task only runs when the sending tasks are in the Blocked state,
+        and the sending tasks only block when the queue is full, this task should
+        always find the queue to be full.  3 is the queue length. */
+        if( uxQueueMessagesWaiting( xQueue ) != 3 )
+        {
+            vPrintString( "Queue should have been full!\r\n" );
+        }
 
-		/* The first parameter is the queue from which data is to be received.  The
-		queue is created before the scheduler is started, and therefore before this
-		task runs for the first time.
+        /* The first parameter is the queue from which data is to be received.  The
+        queue is created before the scheduler is started, and therefore before this
+        task runs for the first time.
 
-		The second parameter is the buffer into which the received data will be
-		placed.  In this case the buffer is simply the address of a variable that
-		has the required size to hold the received structure.
+        The second parameter is the buffer into which the received data will be
+        placed.  In this case the buffer is simply the address of a variable that
+        has the required size to hold the received structure.
 
-		The last parameter is the block time - the maximum amount of time that the
-		task should remain in the Blocked state to wait for data to be available
-		should the queue already be empty.  A block time is not necessary as this
-		task will only run when the queue is full so data will always be available. */
-		xStatus = xQueueReceive( xQueue, &xReceivedStructure, 0 );
+        The last parameter is the block time - the maximum amount of time that the
+        task should remain in the Blocked state to wait for data to be available
+        should the queue already be empty.  A block time is not necessary as this
+        task will only run when the queue is full so data will always be available. */
+        xStatus = xQueueReceive( xQueue, &xReceivedStructure, 0 );
 
-		if( xStatus == pdPASS )
-		{
-			/* Data was successfully received from the queue, print out the received
-			value and the source of the value. */
-			if( xReceivedStructure.eDataSource == eSender1 )
-			{
-				vPrintStringAndNumber( "From Sender 1 = ", xReceivedStructure.ucValue );
-			}
-			else
-			{
-				vPrintStringAndNumber( "From Sender 2 = ", xReceivedStructure.ucValue );
-			}
-		}
-		else
-		{
-			/* We did not receive anything from the queue.  This must be an error
-			as this task should only run when the queue is full. */
-			vPrintString( "Could not receive from the queue.\r\n" );
-		}
-	}
+        if( xStatus == pdPASS )
+        {
+            /* Data was successfully received from the queue, print out the received
+            value and the source of the value. */
+            if( xReceivedStructure.eDataSource == eSender1 )
+            {
+                vPrintStringAndNumber( "From Sender 1 = ", xReceivedStructure.ucValue );
+            }
+            else
+            {
+                vPrintStringAndNumber( "From Sender 2 = ", xReceivedStructure.ucValue );
+            }
+        }
+        else
+        {
+            /* We did not receive anything from the queue.  This must be an error
+            as this task should only run when the queue is full. */
+            vPrintString( "Could not receive from the queue.\r\n" );
+        }
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example012/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example012/main.c
@@ -81,37 +81,37 @@ static QueueSetHandle_t xQueueSet = NULL;
 
 int main( void )
 {
-	/* Create the two queues.  Each queue sends character pointers.  The
-	priority of the receiving task is above the priority of the sending tasks so
-	the queues will never have more than one item in them at any one time. */
+    /* Create the two queues.  Each queue sends character pointers.  The
+    priority of the receiving task is above the priority of the sending tasks so
+    the queues will never have more than one item in them at any one time. */
     xQueue1 = xQueueCreate( 1, sizeof( char * ) );
-	xQueue2 = xQueueCreate( 1, sizeof( char * ) );
+    xQueue2 = xQueueCreate( 1, sizeof( char * ) );
 
-	/* Create the queue set.  There are two queues both of which can contain
-	1 item, so the maximum number of queue handle the queue set will ever have
-	to hold is 2 (1 item multiplied by 2 sets). */
-	xQueueSet = xQueueCreateSet( 1 * 2 );
+    /* Create the queue set.  There are two queues both of which can contain
+    1 item, so the maximum number of queue handle the queue set will ever have
+    to hold is 2 (1 item multiplied by 2 sets). */
+    xQueueSet = xQueueCreateSet( 1 * 2 );
 
-	/* Add the two queues to the set. */
-	xQueueAddToSet( xQueue1, xQueueSet );
-	xQueueAddToSet( xQueue2, xQueueSet );
+    /* Add the two queues to the set. */
+    xQueueAddToSet( xQueue1, xQueueSet );
+    xQueueAddToSet( xQueue2, xQueueSet );
 
-	/* Create the tasks that send to the queues. */
-	xTaskCreate( vSenderTask1, "Sender1", 1000, NULL, 1, NULL );
-	xTaskCreate( vSenderTask2, "Sender2", 1000, NULL, 1, NULL );
+    /* Create the tasks that send to the queues. */
+    xTaskCreate( vSenderTask1, "Sender1", 1000, NULL, 1, NULL );
+    xTaskCreate( vSenderTask2, "Sender2", 1000, NULL, 1, NULL );
 
-	/* Create the receiver task. */
-	xTaskCreate( vReceiverTask, "Receiver", 1000, NULL, 2, NULL );
+    /* Create the receiver task. */
+    xTaskCreate( vReceiverTask, "Receiver", 1000, NULL, 2, NULL );
 
-	/* Start the scheduler so the created tasks start executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created tasks start executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -120,21 +120,21 @@ static void vSenderTask1( void *pvParameters )
 const TickType_t xBlockTime = pdMS_TO_TICKS( 100 );
 const char * const pcMessage = "Message from vSenderTask1\r\n";
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* Block for 100ms. */
-		vTaskDelay( xBlockTime );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* Block for 100ms. */
+        vTaskDelay( xBlockTime );
 
-		/* Send this task's string to xQueue1. It is not necessary to use a
-		block time, even though the queue can only hold one item.  This is
-		because the priority of the task that reads from the queue is higher
-		than the priority of this task; as soon as this task writes to the queue
-		it will be pre-empted by the task that reads from the queue, so the
-		queue will already be empty again by the time the call to xQueueSend()
-		returns.  The block time is set to 0. */
-		xQueueSend( xQueue1, &pcMessage, 0 );
-	}
+        /* Send this task's string to xQueue1. It is not necessary to use a
+        block time, even though the queue can only hold one item.  This is
+        because the priority of the task that reads from the queue is higher
+        than the priority of this task; as soon as this task writes to the queue
+        it will be pre-empted by the task that reads from the queue, so the
+        queue will already be empty again by the time the call to xQueueSend()
+        returns.  The block time is set to 0. */
+        xQueueSend( xQueue1, &pcMessage, 0 );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -143,21 +143,21 @@ static void vSenderTask2( void *pvParameters )
 const TickType_t xBlockTime = pdMS_TO_TICKS( 200 );
 const char * const pcMessage = "Message from vSenderTask2\r\n";
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* Block for 200ms. */
-		vTaskDelay( xBlockTime );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* Block for 200ms. */
+        vTaskDelay( xBlockTime );
 
-		/* Send this task's string to xQueue1. It is not necessary to use a
-		block time, even though the queue can only hold one item.  This is
-		because the priority of the task that reads from the queue is higher
-		than the priority of this task; as soon as this task writes to the queue
-		it will be pre-empted by the task that reads from the queue, so the
-		queue will already be empty again by the time the call to xQueueSend()
-		returns.  The block time is set to 0. */
-		xQueueSend( xQueue2, &pcMessage, 0 );
-	}
+        /* Send this task's string to xQueue1. It is not necessary to use a
+        block time, even though the queue can only hold one item.  This is
+        because the priority of the task that reads from the queue is higher
+        than the priority of this task; as soon as this task writes to the queue
+        it will be pre-empted by the task that reads from the queue, so the
+        queue will already be empty again by the time the call to xQueueSend()
+        returns.  The block time is set to 0. */
+        xQueueSend( xQueue2, &pcMessage, 0 );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -166,25 +166,25 @@ static void vReceiverTask( void *pvParameters )
 QueueHandle_t xQueueThatContainsData;
 char *pcReceivedString;
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* Block on the queue set to wait for one of the queues in the set to
-		contain data.  Cast the QueueSetMemberHandle_t values returned from
-		xQueueSelectFromSet() to a QueueHandle_t as it is known that all the
-		items in the set are queues (as opposed to semaphores, which can also be
-		members of a queue set). */
-		xQueueThatContainsData = ( QueueHandle_t ) xQueueSelectFromSet( xQueueSet, portMAX_DELAY );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* Block on the queue set to wait for one of the queues in the set to
+        contain data.  Cast the QueueSetMemberHandle_t values returned from
+        xQueueSelectFromSet() to a QueueHandle_t as it is known that all the
+        items in the set are queues (as opposed to semaphores, which can also be
+        members of a queue set). */
+        xQueueThatContainsData = ( QueueHandle_t ) xQueueSelectFromSet( xQueueSet, portMAX_DELAY );
 
-		/* An indefinite block time was used when reading from the set so
-		xQueueSelectFromSet() will not have returned unless one of the queues in
-		the set contained data, and xQueueThatContansData must be valid.  Read
-		from the queue.  It is not necessary to specify a block time because it
-		is known that the queue contains data.  The block time is set to 0. */
-		xQueueReceive( xQueueThatContainsData, &pcReceivedString, 0 );
+        /* An indefinite block time was used when reading from the set so
+        xQueueSelectFromSet() will not have returned unless one of the queues in
+        the set contained data, and xQueueThatContansData must be valid.  Read
+        from the queue.  It is not necessary to specify a block time because it
+        is known that the queue contains data.  The block time is set to 0. */
+        xQueueReceive( xQueueThatContainsData, &pcReceivedString, 0 );
 
-		/* Print the string received from the queue. */
-		vPrintString( pcReceivedString );
-	}
+        /* Print the string received from the queue. */
+        vPrintString( pcReceivedString );
+    }
 }
 

--- a/examples/Win32-simulator-MSVC/Examples/Example013/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example013/main.c
@@ -62,8 +62,8 @@
 #include "supporting_functions.h"
 
 /* The periods assigned to the one-shot and auto-reload timers respectively. */
-#define mainONE_SHOT_TIMER_PERIOD		( pdMS_TO_TICKS( 3333UL ) )
-#define mainAUTO_RELOAD_TIMER_PERIOD	( pdMS_TO_TICKS( 500UL ) )
+#define mainONE_SHOT_TIMER_PERIOD        ( pdMS_TO_TICKS( 3333UL ) )
+#define mainAUTO_RELOAD_TIMER_PERIOD    ( pdMS_TO_TICKS( 500UL ) )
 
 /*-----------------------------------------------------------*/
 
@@ -81,51 +81,51 @@ int main( void )
 TimerHandle_t xAutoReloadTimer, xOneShotTimer;
 BaseType_t xTimer1Started, xTimer2Started;
 
-	/* Create the one shot software timer, storing the handle to the created
-	software timer in xOneShotTimer. */
-	xOneShotTimer = xTimerCreate( "OneShot",					/* Text name for the software timer - not used by FreeRTOS. */
-								  mainONE_SHOT_TIMER_PERIOD,	/* The software timer's period in ticks. */
-								  pdFALSE,						/* Setting uxAutoRealod to pdFALSE creates a one-shot software timer. */
-								  0,							/* This example does not use the timer id. */
-								  prvOneShotTimerCallback );	/* The callback function to be used by the software timer being created. */
+    /* Create the one shot software timer, storing the handle to the created
+    software timer in xOneShotTimer. */
+    xOneShotTimer = xTimerCreate( "OneShot",                    /* Text name for the software timer - not used by FreeRTOS. */
+                                  mainONE_SHOT_TIMER_PERIOD,    /* The software timer's period in ticks. */
+                                  pdFALSE,                        /* Setting uxAutoRealod to pdFALSE creates a one-shot software timer. */
+                                  0,                            /* This example does not use the timer id. */
+                                  prvOneShotTimerCallback );    /* The callback function to be used by the software timer being created. */
 
-	/* Create the auto-reload software timer, storing the handle to the created
-	software timer in xAutoReloadTimer. */
-	xAutoReloadTimer = xTimerCreate( "AutoReload",					/* Text name for the software timer - not used by FreeRTOS. */
-									 mainAUTO_RELOAD_TIMER_PERIOD,	/* The software timer's period in ticks. */
-									 pdTRUE,						/* Set uxAutoRealod to pdTRUE to create an auto-reload software timer. */
-									 0,								/* This example does not use the timer id. */
-									 prvAutoReloadTimerCallback );	/* The callback function to be used by the software timer being created. */
+    /* Create the auto-reload software timer, storing the handle to the created
+    software timer in xAutoReloadTimer. */
+    xAutoReloadTimer = xTimerCreate( "AutoReload",                    /* Text name for the software timer - not used by FreeRTOS. */
+                                     mainAUTO_RELOAD_TIMER_PERIOD,    /* The software timer's period in ticks. */
+                                     pdTRUE,                        /* Set uxAutoRealod to pdTRUE to create an auto-reload software timer. */
+                                     0,                                /* This example does not use the timer id. */
+                                     prvAutoReloadTimerCallback );    /* The callback function to be used by the software timer being created. */
 
-	/* Check the timers were created. */
-	if( ( xOneShotTimer != NULL ) && ( xAutoReloadTimer != NULL ) )
-	{
-		/* Start the software timers, using a block time of 0 (no block time).
-		The scheduler has not been started yet so any block time specified here
-		would be ignored anyway. */
-		xTimer1Started = xTimerStart( xOneShotTimer, 0 );
-		xTimer2Started = xTimerStart( xAutoReloadTimer, 0 );
+    /* Check the timers were created. */
+    if( ( xOneShotTimer != NULL ) && ( xAutoReloadTimer != NULL ) )
+    {
+        /* Start the software timers, using a block time of 0 (no block time).
+        The scheduler has not been started yet so any block time specified here
+        would be ignored anyway. */
+        xTimer1Started = xTimerStart( xOneShotTimer, 0 );
+        xTimer2Started = xTimerStart( xAutoReloadTimer, 0 );
 
-		/* The implementation of xTimerStart() uses the timer command queue, and
-		xTimerStart() will fail if the timer command queue gets full.  The timer
-		service task does not get created until the scheduler is started, so all
-		commands sent to the command queue will stay in the queue until after
-		the scheduler has been started.  Check both calls to xTimerStart()
-		passed. */
-		if( ( xTimer1Started == pdPASS ) && ( xTimer2Started == pdPASS ) )
-		{
-			/* Start the scheduler. */
-			vTaskStartScheduler();
-		}
-	}
+        /* The implementation of xTimerStart() uses the timer command queue, and
+        xTimerStart() will fail if the timer command queue gets full.  The timer
+        service task does not get created until the scheduler is started, so all
+        commands sent to the command queue will stay in the queue until after
+        the scheduler has been started.  Check both calls to xTimerStart()
+        passed. */
+        if( ( xTimer1Started == pdPASS ) && ( xTimer2Started == pdPASS ) )
+        {
+            /* Start the scheduler. */
+            vTaskStartScheduler();
+        }
+    }
 
-	/* If the scheduler was started then the following line should never be
-	reached because vTaskStartScheduler() will only return if there was not
-	enough FreeRTOS heap memory available to create the Idle and (if configured)
-	Timer tasks.  Heap management, and techniques for trapping heap exhaustion,
-	are described in the book text. */
-	for( ;; );
-	return 0;
+    /* If the scheduler was started then the following line should never be
+    reached because vTaskStartScheduler() will only return if there was not
+    enough FreeRTOS heap memory available to create the Idle and (if configured)
+    Timer tasks.  Heap management, and techniques for trapping heap exhaustion,
+    are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -133,11 +133,11 @@ static void prvOneShotTimerCallback( TimerHandle_t xTimer )
 {
 static TickType_t xTimeNow;
 
-	/* Obtain the current tick count. */
-	xTimeNow = xTaskGetTickCount();
+    /* Obtain the current tick count. */
+    xTimeNow = xTaskGetTickCount();
 
-	/* Output a string to show the time at which the callback was executed. */
-	vPrintStringAndNumber( "One-shot timer callback executing", xTimeNow );
+    /* Output a string to show the time at which the callback was executed. */
+    vPrintStringAndNumber( "One-shot timer callback executing", xTimeNow );
 }
 /*-----------------------------------------------------------*/
 
@@ -145,11 +145,11 @@ static void prvAutoReloadTimerCallback( TimerHandle_t xTimer )
 {
 static TickType_t xTimeNow;
 
-	/* Obtain the current tick count. */
-	xTimeNow = xTaskGetTickCount();
+    /* Obtain the current tick count. */
+    xTimeNow = xTaskGetTickCount();
 
-	/* Output a string to show the time at which the callback was executed. */
-	vPrintStringAndNumber( "Auto-reload timer callback executing", xTimeNow );
+    /* Output a string to show the time at which the callback was executed. */
+    vPrintStringAndNumber( "Auto-reload timer callback executing", xTimeNow );
 }
 /*-----------------------------------------------------------*/
 

--- a/examples/Win32-simulator-MSVC/Examples/Example014/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example014/main.c
@@ -62,8 +62,8 @@
 #include "supporting_functions.h"
 
 /* The periods assigned to the one-shot and auto-reload timers respectively. */
-#define mainONE_SHOT_TIMER_PERIOD		( pdMS_TO_TICKS( 3333UL ) )
-#define mainAUTO_RELOAD_TIMER_PERIOD	( pdMS_TO_TICKS( 500UL ) )
+#define mainONE_SHOT_TIMER_PERIOD        ( pdMS_TO_TICKS( 3333UL ) )
+#define mainAUTO_RELOAD_TIMER_PERIOD    ( pdMS_TO_TICKS( 500UL ) )
 
 /*-----------------------------------------------------------*/
 
@@ -80,95 +80,96 @@ static TimerHandle_t xAutoReloadTimer, xOneShotTimer;
 
 int main( void )
 {
-BaseType_t xTimer1Started, xTimer2Started;
+    BaseType_t xTimer1Started, xTimer2Started;
 
-	/* Create the one shot timer, storing the handle to the created timer in
-	xOneShotTimer. */
-	xOneShotTimer = xTimerCreate( "OneShot",					/* Text name for the timer - not used by FreeRTOS. */
-								  mainONE_SHOT_TIMER_PERIOD,	/* The timer's period in ticks. */
-								  pdFALSE,						/* Set uxAutoRealod to pdFALSE to create a one-shot timer. */
-								  0,							/* The timer ID is initialised to 0. */
-								  prvTimerCallback );			/* The callback function to be used by the timer being created. */
+    /* Create the one shot timer, storing the handle to the created timer in
+    xOneShotTimer. */
+    xOneShotTimer = xTimerCreate( "OneShot",                    /* Text name for the timer - not used by FreeRTOS. */
+                                  mainONE_SHOT_TIMER_PERIOD,    /* The timer's period in ticks. */
+                                  pdFALSE,                        /* Set uxAutoRealod to pdFALSE to create a one-shot timer. */
+                                  0,                            /* The timer ID is initialised to 0. */
+                                  prvTimerCallback );            /* The callback function to be used by the timer being created. */
 
-	/* Create the auto-reload, storing the handle to the created timer in
-	xAutoReloadTimer. */
-	xAutoReloadTimer = xTimerCreate( "AutoReload",					/* Text name for the timer - not used by FreeRTOS. */
-									 mainAUTO_RELOAD_TIMER_PERIOD,	/* The timer's period in ticks. */
-									 pdTRUE,						/* Set uxAutoRealod to pdTRUE to create an auto-reload timer. */
-									 0,								/* The timer ID is initialised to 0. */
-									 prvTimerCallback );			/* The callback function to be used by the timer being created. */
+    /* Create the auto-reload, storing the handle to the created timer in
+    xAutoReloadTimer. */
+    xAutoReloadTimer = xTimerCreate( "AutoReload",                    /* Text name for the timer - not used by FreeRTOS. */
+                                     mainAUTO_RELOAD_TIMER_PERIOD,    /* The timer's period in ticks. */
+                                     pdTRUE,                        /* Set uxAutoRealod to pdTRUE to create an auto-reload timer. */
+                                     0,                                /* The timer ID is initialised to 0. */
+                                     prvTimerCallback );            /* The callback function to be used by the timer being created. */
 
-	/* Check the timers were created. */
-	if( ( xOneShotTimer != NULL ) && ( xAutoReloadTimer != NULL ) )
-	{
-		/* Start the timers, using a block time of 0 (no block time).  The
-		scheduler has not been started yet so any block time specified here
-		would be ignored anyway. */
-		xTimer1Started = xTimerStart( xOneShotTimer, 0 );
-		xTimer2Started = xTimerStart( xAutoReloadTimer, 0 );
+    /* Check the timers were created. */
+    if( ( xOneShotTimer != NULL ) && ( xAutoReloadTimer != NULL ) )
+    {
+        /* Start the timers, using a block time of 0 (no block time).  The
+        scheduler has not been started yet so any block time specified here
+        would be ignored anyway. */
+        xTimer1Started = xTimerStart( xOneShotTimer, 0 );
+        xTimer2Started = xTimerStart( xAutoReloadTimer, 0 );
 
-		/* The implementation of xTimerStart() uses the timer command queue, and
-		xTimerStart() will fail if the timer command queue gets full.  The timer
-		service task does not get created until the scheduler is started, so all
-		commands sent to the command queue will stay in the queue until after
-		the scheduler has been started.  Check both calls to xTimerStart()
-		passed. */
-		if( ( xTimer1Started == pdPASS ) && ( xTimer2Started == pdPASS ) )
-		{
-			/* Start the scheduler. */
-			vTaskStartScheduler();
-		}
-	}
+        /* The implementation of xTimerStart() uses the timer command queue, and
+        xTimerStart() will fail if the timer command queue gets full.  The timer
+        service task does not get created until the scheduler is started, so all
+        commands sent to the command queue will stay in the queue until after
+        the scheduler has been started.  Check both calls to xTimerStart()
+        passed. */
+        if( ( xTimer1Started == pdPASS ) && ( xTimer2Started == pdPASS ) )
+        {
+            /* Start the scheduler. */
+            vTaskStartScheduler();
+        }
+    }
 
-	/* If the scheduler was started then the following line should never be
-	reached because vTaskStartScheduler() will only return if there was not
-	enough FreeRTOS heap memory available to create the Idle and (if configured)
-	Timer tasks.  Heap management, and techniques for trapping heap exhaustion,
-	are described in the book text. */
-	for( ;; );
-	return 0;
+    /* If the scheduler was started then the following line should never be
+    reached because vTaskStartScheduler() will only return if there was not
+    enough FreeRTOS heap memory available to create the Idle and (if configured)
+    Timer tasks.  Heap management, and techniques for trapping heap exhaustion,
+    are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 static void prvTimerCallback( TimerHandle_t xTimer )
 {
-TickType_t xTimeNow;
-uint32_t ulExecutionCount;
+    TickType_t xTimeNow;
+    uint32_t ulExecutionCount;
 
-	/* The count of the number of times this software timer has expired is
-	stored in the timer's ID.  Obtain the ID, increment it, then save it as the
-	new ID value.  The ID is a void pointer, so is cast to a uint32_t. */
-	ulExecutionCount = ( uint32_t ) pvTimerGetTimerID( xTimer );
-	ulExecutionCount++;
-	vTimerSetTimerID( xTimer, ( void * ) ulExecutionCount );
+    /* The count of the number of times this software timer has expired is
+    stored in the timer's ID.  Obtain the ID, increment it, then save it as the
+    new ID value.  The ID is a void pointer, so is cast to a uint32_t. */
+    ulExecutionCount = ( uint32_t ) pvTimerGetTimerID( xTimer );
+    ulExecutionCount++;
+    vTimerSetTimerID( xTimer, ( void * ) ulExecutionCount );
 
-	/* Obtain the current tick count. */
-	xTimeNow = xTaskGetTickCount();
+    /* Obtain the current tick count. */
+    xTimeNow = xTaskGetTickCount();
 
     /* The handle of the one-shot timer was stored in xOneShotTimer when the
-	timer was created.  Compare the handle passed into this function with
-	xOneShotTimer to determine if it was the one-shot or auto-reload timer that
-	expired, then output a string to show the time at which the callback was
-	executed. */
-	if( xTimer == xOneShotTimer )
-	{
-		vPrintStringAndNumber( "One-shot timer callback executing", xTimeNow );
-	}
-	else
-	{
+    timer was created.  Compare the handle passed into this function with
+    xOneShotTimer to determine if it was the one-shot or auto-reload timer that
+    expired, then output a string to show the time at which the callback was
+    executed. */
+    if( xTimer == xOneShotTimer )
+    {
+        vPrintStringAndNumber( "One-shot timer callback executing", xTimeNow );
+    }
+    else
+    {
         /* xTimer did not equal xOneShotTimer, so it must be the auto-reload
-		timer that expired. */
-		vPrintStringAndNumber( "Auto-reload timer callback executing", xTimeNow );
+        timer that expired. */
+        vPrintStringAndNumber( "Auto-reload timer callback executing", xTimeNow );
 
-		if( ulExecutionCount == 5 )
-		{
-			/* Stop the auto-reload timer after it has executed 5 times.  This
-			callback function executes in the context of the RTOS daemon task so
-			must not call any functions that might place the daemon task into
-			the Blocked state.  Therefore a block time of 0 is used. */
-			xTimerStop( xTimer, 0 );
-		}
-	}
+        if( ulExecutionCount == 5 )
+        {
+            /* Stop the auto-reload timer after it has executed 5 times.  This
+            callback function executes in the context of the RTOS daemon task so
+            must not call any functions that might place the daemon task into
+            the Blocked state.  Therefore a block time of 0 is used. */
+            xTimerStop( xTimer, 0 );
+            vPrintString( "\nStopping the Auto-reload timer" );
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 

--- a/examples/Win32-simulator-MSVC/Examples/Example015/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example015/main.c
@@ -131,7 +131,7 @@ int main( void )
 
 static void prvBacklightTimerCallback( TimerHandle_t xTimer )
 {
-TickType_t xTimeNow = xTaskGetTickCount();
+	TickType_t xTimeNow = xTaskGetTickCount();
 
 	/* The backlight timer expired, turn the backlight off. */
 	xSimulatedBacklightOn = pdFALSE;
@@ -143,9 +143,9 @@ TickType_t xTimeNow = xTaskGetTickCount();
 
 static void vKeyHitTask( void *pvParameters )
 {
-const TickType_t xShortDelay = pdMS_TO_TICKS( 50 );
-extern BaseType_t xKeyPressesStopApplication;
-TickType_t xTimeNow;
+	const TickType_t xShortDelay = pdMS_TO_TICKS( 50 );
+	extern BaseType_t xKeyPressesStopApplication;
+	TickType_t xTimeNow;
 
 	/* This example uses key presses, so prevent key presses being used to end
 	the application. */

--- a/examples/Win32-simulator-MSVC/Examples/Example016/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example016/main.c
@@ -74,7 +74,7 @@
 /* The number of the simulated interrupt used in this example.  Numbers 0 to 2
 are used by the FreeRTOS Windows port itself, so 3 is the first number available
 to the application. */
-#define mainINTERRUPT_NUMBER	3
+#define mainINTERRUPT_NUMBER    3
 
 /* The tasks to be created. */
 static void vHandlerTask( void *pvParameters );
@@ -93,59 +93,59 @@ SemaphoreHandle_t xBinarySemaphore;
 int main( void )
 {
     /* Before a semaphore is used it must be explicitly created.  In this
-	example	a binary semaphore is created. */
+    example    a binary semaphore is created. */
     xBinarySemaphore = xSemaphoreCreateBinary();
 
-	/* Check the semaphore was created successfully. */
-	if( xBinarySemaphore != NULL )
-	{
-		/* Create the 'handler' task, which is the task to which interrupt
-		processing is deferred, and so is the task that will be synchronized
-		with the interrupt.  The handler task is created with a high priority to
-		ensure it runs immediately after the interrupt exits.  In this case a
-		priority of 3 is chosen. */
-		xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, NULL );
+    /* Check the semaphore was created successfully. */
+    if( xBinarySemaphore != NULL )
+    {
+        /* Create the 'handler' task, which is the task to which interrupt
+        processing is deferred, and so is the task that will be synchronized
+        with the interrupt.  The handler task is created with a high priority to
+        ensure it runs immediately after the interrupt exits.  In this case a
+        priority of 3 is chosen. */
+        xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, NULL );
 
-		/* Create the task that will periodically generate a software interrupt.
-		This is created with a priority below the handler task to ensure it will
-		get preempted each time the handler task exits the Blocked state. */
-		xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
+        /* Create the task that will periodically generate a software interrupt.
+        This is created with a priority below the handler task to ensure it will
+        get preempted each time the handler task exits the Blocked state. */
+        xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
 
-		/* Install the handler for the software interrupt.  The syntax necessary
-		to do this is dependent on the FreeRTOS port being used.  The syntax
-		shown here can only be used with the FreeRTOS Windows port, where such
-		interrupts are only simulated. */
-		vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
+        /* Install the handler for the software interrupt.  The syntax necessary
+        to do this is dependent on the FreeRTOS port being used.  The syntax
+        shown here can only be used with the FreeRTOS Windows port, where such
+        interrupts are only simulated. */
+        vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
-		/* Start the scheduler so the created tasks start executing. */
-		vTaskStartScheduler();
-	}
+        /* Start the scheduler so the created tasks start executing. */
+        vTaskStartScheduler();
+    }
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 static void vHandlerTask( void *pvParameters )
 {
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* Use the semaphore to wait for the event.  The semaphore was created
-		before the scheduler was started so before this task ran for the first
-		time.  The task blocks indefinitely meaning this function call will only
-		return once the semaphore has been successfully obtained - so there is
-		no need to check the returned value. */
-		xSemaphoreTake( xBinarySemaphore, portMAX_DELAY );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* Use the semaphore to wait for the event.  The semaphore was created
+        before the scheduler was started so before this task ran for the first
+        time.  The task blocks indefinitely meaning this function call will only
+        return once the semaphore has been successfully obtained - so there is
+        no need to check the returned value. */
+        xSemaphoreTake( xBinarySemaphore, portMAX_DELAY );
 
-		/* To get here the event must have occurred.  Process the event (in this
-		case just print out a message). */
-		vPrintString( "Handler task - Processing event.\r\n" );
-	}
+        /* To get here the event must have occurred.  Process the event (in this
+        case just print out a message). */
+        vPrintString( "Handler task - Processing event.\r\n" );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -153,26 +153,26 @@ static void vPeriodicTask( void *pvParameters )
 {
 const TickType_t xDelay500ms = pdMS_TO_TICKS( 500UL );
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* This task is just used to 'simulate' an interrupt.  This is done by
-		periodically generating a simulated software interrupt.  Block until it
-		is time to generate the software interrupt again. */
-		vTaskDelay( xDelay500ms );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* This task is just used to 'simulate' an interrupt.  This is done by
+        periodically generating a simulated software interrupt.  Block until it
+        is time to generate the software interrupt again. */
+        vTaskDelay( xDelay500ms );
 
-		/* Generate the interrupt, printing a message both before and after
-		the interrupt has been generated so the sequence of execution is evident
-		from the output.
+        /* Generate the interrupt, printing a message both before and after
+        the interrupt has been generated so the sequence of execution is evident
+        from the output.
 
-		The syntax used to generate a software interrupt is dependent on the
-		FreeRTOS port being used.  The syntax used below can only be used with
-		the FreeRTOS Windows port, in which such interrupts are only
-		simulated. */
-		vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
-		vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
-		vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
-	}
+        The syntax used to generate a software interrupt is dependent on the
+        FreeRTOS port being used.  The syntax used below can only be used with
+        the FreeRTOS Windows port, in which such interrupts are only
+        simulated. */
+        vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
+        vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
+        vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -180,22 +180,22 @@ static uint32_t ulExampleInterruptHandler( void )
 {
 BaseType_t xHigherPriorityTaskWoken;
 
-	/* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
-	it will get set to pdTRUE inside the interrupt safe API function if a
-	context switch is required. */
-	xHigherPriorityTaskWoken = pdFALSE;
+    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
+    it will get set to pdTRUE inside the interrupt safe API function if a
+    context switch is required. */
+    xHigherPriorityTaskWoken = pdFALSE;
 
-	/* 'Give' the semaphore to unblock the task. */
-	xSemaphoreGiveFromISR( xBinarySemaphore, &xHigherPriorityTaskWoken );
+    /* 'Give' the semaphore to unblock the task. */
+    xSemaphoreGiveFromISR( xBinarySemaphore, &xHigherPriorityTaskWoken );
 
-	/* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
-	xHigherPriorityTaskWoken was set to pdTRUE inside xSemaphoreGiveFromISR()
-	then calling portYIELD_FROM_ISR() will request a context switch.  If
-	xHigherPriorityTaskWoken is still pdFALSE then calling
-	portYIELD_FROM_ISR() will have no effect.  The implementation of
-	portYIELD_FROM_ISR() used by the Windows port includes a return statement,
-	which is why this function does not explicitly return a value. */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
+    xHigherPriorityTaskWoken was set to pdTRUE inside xSemaphoreGiveFromISR()
+    then calling portYIELD_FROM_ISR() will request a context switch.  If
+    xHigherPriorityTaskWoken is still pdFALSE then calling
+    portYIELD_FROM_ISR() will have no effect.  The implementation of
+    portYIELD_FROM_ISR() used by the Windows port includes a return statement,
+    which is why this function does not explicitly return a value. */
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example017/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example017/main.c
@@ -135,6 +135,9 @@ int main( void )
 
 static void vHandlerTask( void *pvParameters )
 {
+	/* Remove compiler warning about unused parameter. */
+	( void ) pvParameters; 
+
 	/* As per most tasks, this task is implemented within an infinite loop. */
 	for( ;; )
 	{
@@ -154,7 +157,11 @@ static void vHandlerTask( void *pvParameters )
 
 static void vPeriodicTask( void *pvParameters )
 {
-const TickType_t xDelay500ms = pdMS_TO_TICKS( 500UL );
+	
+	/* Remove compiler warning about unused parameter. */
+	(void)pvParameters;
+
+	const TickType_t xDelay500ms = pdMS_TO_TICKS( 500UL );
 
 	/* As per most tasks, this task is implemented within an infinite loop. */
 	for( ;; )
@@ -181,7 +188,7 @@ const TickType_t xDelay500ms = pdMS_TO_TICKS( 500UL );
 
 static uint32_t ulExampleInterruptHandler( void )
 {
-BaseType_t xHigherPriorityTaskWoken;
+	BaseType_t xHigherPriorityTaskWoken;
 
 	/* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
 	it will get set to pdTRUE inside the interrupt safe API function if a

--- a/examples/Win32-simulator-MSVC/Examples/Example018/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example018/main.c
@@ -75,7 +75,7 @@
 /* The number of the simulated interrupt used in this example.  Numbers 0 to 2
 are used by the FreeRTOS Windows port itself, so 3 is the first number available
 to the application. */
-#define mainINTERRUPT_NUMBER	3
+#define mainINTERRUPT_NUMBER    3
 
 /* The task to be created. */
 static void vPeriodicTask( void *pvParameters );
@@ -98,24 +98,24 @@ set by the configTIMER_TASK_PRIORITY compile time configuration constant in
 FreeRTOSConfig.h. */
 const UBaseType_t ulPeriodicTaskPriority = configTIMER_TASK_PRIORITY - 1;
 
-	/* Create the task that will periodically generate a software interrupt. */
-	xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, ulPeriodicTaskPriority, NULL );
+    /* Create the task that will periodically generate a software interrupt. */
+    xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, ulPeriodicTaskPriority, NULL );
 
-	/* Install the handler for the software interrupt.  The syntax necessary
-	to do this is dependent on the FreeRTOS port being used.  The syntax
-	shown here can only be used with the FreeRTOS Windows port, where such
-	interrupts are only simulated. */
-	vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
+    /* Install the handler for the software interrupt.  The syntax necessary
+    to do this is dependent on the FreeRTOS port being used.  The syntax
+    shown here can only be used with the FreeRTOS Windows port, where such
+    interrupts are only simulated. */
+    vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
-	/* Start the scheduler so the created task starts executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created task starts executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -123,26 +123,26 @@ static void vPeriodicTask( void *pvParameters )
 {
 const TickType_t xDelay500ms = pdMS_TO_TICKS( 500UL );
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* This task is just used to 'simulate' an interrupt.  This is done by
-		periodically generating a simulated software interrupt.  Block until it
-		is time to generate the software interrupt again. */
-		vTaskDelay( xDelay500ms );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* This task is just used to 'simulate' an interrupt.  This is done by
+        periodically generating a simulated software interrupt.  Block until it
+        is time to generate the software interrupt again. */
+        vTaskDelay( xDelay500ms );
 
-		/* Generate the interrupt, printing a message both before and after
-		the interrupt has been generated so the sequence of execution is evident
-		from the output.
+        /* Generate the interrupt, printing a message both before and after
+        the interrupt has been generated so the sequence of execution is evident
+        from the output.
 
-		The syntax used to generate a software interrupt is dependent on the
-		FreeRTOS port being used.  The syntax used below can only be used with
-		the FreeRTOS Windows port, in which such interrupts are only
-		simulated. */
-		vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
-		vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
-		vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
-	}
+        The syntax used to generate a software interrupt is dependent on the
+        FreeRTOS port being used.  The syntax used below can only be used with
+        the FreeRTOS Windows port, in which such interrupts are only
+        simulated. */
+        vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
+        vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
+        vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -151,39 +151,39 @@ static uint32_t ulExampleInterruptHandler( void )
 static uint32_t ulParameterValue = 0;
 BaseType_t xHigherPriorityTaskWoken;
 
-	/* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
-	it will get set to pdTRUE inside the interrupt safe API function if a
-	context switch is required. */
-	xHigherPriorityTaskWoken = pdFALSE;
+    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
+    it will get set to pdTRUE inside the interrupt safe API function if a
+    context switch is required. */
+    xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Send a pointer to the interrupt's deferred handling function to the
-	daemon task.  The deferred handling function's pvParameter1 parameter is not
-	used so just set to NULL.  The deferred handling function's ulParameter2
-	parameter is used to pass a number that is incremented by one each time this
-	interrupt occurs. */
-	xTimerPendFunctionCallFromISR( vDeferredHandlingFunction, NULL, ulParameterValue, &xHigherPriorityTaskWoken );
-	ulParameterValue++;
+    /* Send a pointer to the interrupt's deferred handling function to the
+    daemon task.  The deferred handling function's pvParameter1 parameter is not
+    used so just set to NULL.  The deferred handling function's ulParameter2
+    parameter is used to pass a number that is incremented by one each time this
+    interrupt occurs. */
+    xTimerPendFunctionCallFromISR( vDeferredHandlingFunction, NULL, ulParameterValue, &xHigherPriorityTaskWoken );
+    ulParameterValue++;
 
-	/* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
-	xHigherPriorityTaskWoken was set to pdTRUE inside
-	xTimerPendFunctionCallFromISR()	then calling portYIELD_FROM_ISR() will
-	request a context switch.  If xHigherPriorityTaskWoken is still pdFALSE then
-	calling	portYIELD_FROM_ISR() will have no effect.  The implementation of
-	portYIELD_FROM_ISR() used by the Windows port includes a return statement,
-	which is why this function does not explicitly return a value. */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
+    xHigherPriorityTaskWoken was set to pdTRUE inside
+    xTimerPendFunctionCallFromISR()    then calling portYIELD_FROM_ISR() will
+    request a context switch.  If xHigherPriorityTaskWoken is still pdFALSE then
+    calling    portYIELD_FROM_ISR() will have no effect.  The implementation of
+    portYIELD_FROM_ISR() used by the Windows port includes a return statement,
+    which is why this function does not explicitly return a value. */
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
 static void vDeferredHandlingFunction( void *pvParameter1, uint32_t ulParameter2 )
 {
-	/* Remove the compiler warning indicating that pvParameter1 is not used, as
-	pvParameter1 is not used in this example. */
-	( void ) pvParameter1;
+    /* Remove the compiler warning indicating that pvParameter1 is not used, as
+    pvParameter1 is not used in this example. */
+    ( void ) pvParameter1;
 
-	/* Process the event - in this case just print out a message and the value
-	of ulParameter2. */
-	vPrintStringAndNumber( "Handler function - Processing event ", ulParameter2 );
+    /* Process the event - in this case just print out a message and the value
+    of ulParameter2. */
+    vPrintStringAndNumber( "Handler function - Processing event ", ulParameter2 );
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example019/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example019/main.c
@@ -74,7 +74,7 @@
 /* The number of the simulated interrupt used in this example.  Numbers 0 to 2
 are used by the FreeRTOS Windows port itself, so 3 is the first number available
 to the application. */
-#define mainINTERRUPT_NUMBER	3
+#define mainINTERRUPT_NUMBER    3
 
 /* The tasks to be created. */
 static void vIntegerGenerator( void *pvParameters );
@@ -93,36 +93,36 @@ QueueHandle_t xIntegerQueue, xStringQueue;
 int main( void )
 {
     /* Before a queue can be used it must first be created.  Create both queues
-	used by this example.  One queue can hold variables of type uint32_t,
-	the other queue can hold variables of type char*.  Both queues can hold a
-	maximum of 10 items.  A real application should check the return values to
-	ensure the queues have been successfully created. */
+    used by this example.  One queue can hold variables of type uint32_t,
+    the other queue can hold variables of type char*.  Both queues can hold a
+    maximum of 10 items.  A real application should check the return values to
+    ensure the queues have been successfully created. */
     xIntegerQueue = xQueueCreate( 10, sizeof( uint32_t ) );
-	xStringQueue = xQueueCreate( 10, sizeof( char * ) );
+    xStringQueue = xQueueCreate( 10, sizeof( char * ) );
 
-	/* Create the task that uses a queue to pass integers to the interrupt
-	service	routine.  The task is created at priority 1. */
-	xTaskCreate( vIntegerGenerator, "IntGen", 1000, NULL, 1, NULL );
+    /* Create the task that uses a queue to pass integers to the interrupt
+    service    routine.  The task is created at priority 1. */
+    xTaskCreate( vIntegerGenerator, "IntGen", 1000, NULL, 1, NULL );
 
-	/* Create the task that prints out the strings sent to it from the interrupt
-	service routine.  The task is created at the higher priority of 2. */
-	xTaskCreate( vStringPrinter, "String", 1000, NULL, 2, NULL );
+    /* Create the task that prints out the strings sent to it from the interrupt
+    service routine.  The task is created at the higher priority of 2. */
+    xTaskCreate( vStringPrinter, "String", 1000, NULL, 2, NULL );
 
-	/* Install the handler for the software interrupt.  The syntax necessary
-	to do this is dependent on the FreeRTOS port being used.  The syntax
-	shown here can only be used with the FreeRTOS Windows port, where such
-	interrupts are only simulated. */
-	vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
+    /* Install the handler for the software interrupt.  The syntax necessary
+    to do this is dependent on the FreeRTOS port being used.  The syntax
+    shown here can only be used with the FreeRTOS Windows port, where such
+    interrupts are only simulated. */
+    vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
-	/* Start the scheduler so the created tasks start executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created tasks start executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -133,35 +133,35 @@ const TickType_t xDelay200ms = pdMS_TO_TICKS( 200UL ), xDontBlock = 0;
 uint32_t ulValueToSend = 0;
 BaseType_t i;
 
-	/* Initialize the variable used by the call to vTaskDelayUntil(). */
-	xLastExecutionTime = xTaskGetTickCount();
+    /* Initialize the variable used by the call to vTaskDelayUntil(). */
+    xLastExecutionTime = xTaskGetTickCount();
 
-	for( ;; )
-	{
-		/* This is a periodic task.  Block until it is time to run again.
-		The task will execute every 200ms. */
-		vTaskDelayUntil( &xLastExecutionTime, xDelay200ms );
+    for( ;; )
+    {
+        /* This is a periodic task.  Block until it is time to run again.
+        The task will execute every 200ms. */
+        vTaskDelayUntil( &xLastExecutionTime, xDelay200ms );
 
-		/* Send five numbers to the queue, each value one higher than the
-		previous value.  The numbers are read from the queue by the interrupt
-		service routine.  The interrupt	service routine always empties the
-		queue, so this task is guaranteed to be able to write all five values
-		without needing to specify a block time. */
-		for( i = 0; i < 5; i++ )
-		{
-			xQueueSendToBack( xIntegerQueue, &ulValueToSend, xDontBlock );
-			ulValueToSend++;
-		}
+        /* Send five numbers to the queue, each value one higher than the
+        previous value.  The numbers are read from the queue by the interrupt
+        service routine.  The interrupt    service routine always empties the
+        queue, so this task is guaranteed to be able to write all five values
+        without needing to specify a block time. */
+        for( i = 0; i < 5; i++ )
+        {
+            xQueueSendToBack( xIntegerQueue, &ulValueToSend, xDontBlock );
+            ulValueToSend++;
+        }
 
-		/* Generate the interrupt so the interrupt service routine can read the
-		values from the queue. The syntax used to generate a software interrupt
-		is dependent on the FreeRTOS port being used.  The syntax used below can
-		only be used with the FreeRTOS Windows port, in which such interrupts
-		are only simulated.*/
-		vPrintString( "Generator task - About to generate an interrupt.\r\n" );
-		vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
-		vPrintString( "Generator task - Interrupt generated.\r\n\r\n\r\n" );
-	}
+        /* Generate the interrupt so the interrupt service routine can read the
+        values from the queue. The syntax used to generate a software interrupt
+        is dependent on the FreeRTOS port being used.  The syntax used below can
+        only be used with the FreeRTOS Windows port, in which such interrupts
+        are only simulated.*/
+        vPrintString( "Generator task - About to generate an interrupt.\r\n" );
+        vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
+        vPrintString( "Generator task - Interrupt generated.\r\n\r\n\r\n" );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -169,14 +169,14 @@ static void vStringPrinter( void *pvParameters )
 {
 char *pcString;
 
-	for( ;; )
-	{
-		/* Block on the queue to wait for data to arrive. */
-		xQueueReceive( xStringQueue, &pcString, portMAX_DELAY );
+    for( ;; )
+    {
+        /* Block on the queue to wait for data to arrive. */
+        xQueueReceive( xStringQueue, &pcString, portMAX_DELAY );
 
-		/* Print out the received string. */
-		vPrintString( pcString );
-	}
+        /* Print out the received string. */
+        vPrintString( pcString );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -190,45 +190,45 @@ interrupt service routine's stack, and exist even when the interrupt service
 routine is not executing. */
 static const char *pcStrings[] =
 {
-	"String 0\r\n",
-	"String 1\r\n",
-	"String 2\r\n",
-	"String 3\r\n"
+    "String 0\r\n",
+    "String 1\r\n",
+    "String 2\r\n",
+    "String 3\r\n"
 };
 
-	/* As always, xHigherPriorityTaskWoken is initialized to pdFALSE to be able
-	to detect it getting set to pdTRUE inside an interrupt safe API function. */
-	xHigherPriorityTaskWoken = pdFALSE;
+    /* As always, xHigherPriorityTaskWoken is initialized to pdFALSE to be able
+    to detect it getting set to pdTRUE inside an interrupt safe API function. */
+    xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Read from the queue until the queue is empty. */
-	while( xQueueReceiveFromISR( xIntegerQueue, &ulReceivedNumber, &xHigherPriorityTaskWoken ) != errQUEUE_EMPTY )
-	{
-		/* Truncate the received value to the last two bits (values 0 to 3
-		inc.), then use the truncated value as an index into the pcStrings[]
-		array to select a string (char *) to send on the other queue. */
-		ulReceivedNumber &= 0x03;
-		xQueueSendToBackFromISR( xStringQueue, &pcStrings[ ulReceivedNumber ], &xHigherPriorityTaskWoken );
-	}
+    /* Read from the queue until the queue is empty. */
+    while( xQueueReceiveFromISR( xIntegerQueue, &ulReceivedNumber, &xHigherPriorityTaskWoken ) != errQUEUE_EMPTY )
+    {
+        /* Truncate the received value to the last two bits (values 0 to 3
+        inc.), then use the truncated value as an index into the pcStrings[]
+        array to select a string (char *) to send on the other queue. */
+        ulReceivedNumber &= 0x03;
+        xQueueSendToBackFromISR( xStringQueue, &pcStrings[ ulReceivedNumber ], &xHigherPriorityTaskWoken );
+    }
 
     /* If receiving from xIntegerQueue caused a task to leave the Blocked state,
-	and if the priority of the task that left the Blocked state is higher than
-	the priority of the task in the Running state, then xHigherPriorityTaskWoken
-	will have been set to pdTRUE inside xQueueReceiveFromISR().
+    and if the priority of the task that left the Blocked state is higher than
+    the priority of the task in the Running state, then xHigherPriorityTaskWoken
+    will have been set to pdTRUE inside xQueueReceiveFromISR().
 
     If sending to xStringQueue caused a task to leave the Blocked state, and
     if the priority of the task that left the Blocked state is higher than the
     priority of the task in the Running state, then xHigherPriorityTaskWoken
-	will have been set to pdTRUE inside xQueueSendFromISR().
+    will have been set to pdTRUE inside xQueueSendFromISR().
 
     xHigherPriorityTaskWoken is used as the parameter to portYIELD_FROM_ISR().
-	If xHigherPriorityTaskWoken equals pdTRUE then calling portYIELD_FROM_ISR()
+    If xHigherPriorityTaskWoken equals pdTRUE then calling portYIELD_FROM_ISR()
     will request a context switch.  If xHigherPriorityTaskWoken is still pdFALSE
-	then calling portYIELD_FROM_ISR() will have no effect.
+    then calling portYIELD_FROM_ISR() will have no effect.
 
     The implementation of portYIELD_FROM_ISR() used by the Windows port includes
-	a return statement, which is why this function does not explicitly return a
+    a return statement, which is why this function does not explicitly return a
     value. */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example020/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example020/main.c
@@ -93,60 +93,60 @@ const TickType_t xMaxBlockTimeTicks = 0x20;
 int main( void )
 {
     /* Before a semaphore is used it must be explicitly created.  In this example
-	a mutex type semaphore is created. */
+    a mutex type semaphore is created. */
     xMutex = xSemaphoreCreateMutex();
 
-	/* Check the semaphore was created successfully. */
-	if( xMutex != NULL )
-	{
-		/* Create two instances of the tasks that attempt to write stdout.  The
-		string they attempt to write is passed into the task as the task's
-		parameter.  The tasks are created at different priorities so some
-		pre-emption will occur. */
-		xTaskCreate( prvPrintTask, "Print1", 1000, "Task 1 ******************************************\r\n", 1, NULL );
-		xTaskCreate( prvPrintTask, "Print2", 1000, "Task 2 ------------------------------------------\r\n", 2, NULL );
+    /* Check the semaphore was created successfully. */
+    if( xMutex != NULL )
+    {
+        /* Create two instances of the tasks that attempt to write stdout.  The
+        string they attempt to write is passed into the task as the task's
+        parameter.  The tasks are created at different priorities so some
+        pre-emption will occur. */
+        xTaskCreate( prvPrintTask, "Print1", 1000, "Task 1 ******************************************\r\n", 1, NULL );
+        xTaskCreate( prvPrintTask, "Print2", 1000, "Task 2 ------------------------------------------\r\n", 2, NULL );
 
-		/* Start the scheduler so the created tasks start executing. */
-		vTaskStartScheduler();
-	}
+        /* Start the scheduler so the created tasks start executing. */
+        vTaskStartScheduler();
+    }
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 static void prvNewPrintString( const char *pcString )
 {
-	/* The semaphore is created before the scheduler is started so already
-	exists by the time this task executes.
+    /* The semaphore is created before the scheduler is started so already
+    exists by the time this task executes.
 
-	Attempt to take the semaphore, blocking indefinitely if the mutex is not
-	available immediately.  The call to xSemaphoreTake() will only return when
-	the semaphore has been successfully obtained so there is no need to check the
-	return value.  If any other delay period was used then the code must check
-	that xSemaphoreTake() returns pdTRUE before accessing the resource (in this
-	case standard out. */
-	xSemaphoreTake( xMutex, portMAX_DELAY );
-	{
-		/* The following line will only execute once the semaphore has been
-		successfully obtained - so standard out can be accessed freely. */
-		printf( "%s", pcString );
-		fflush( stdout );
-	}
-	xSemaphoreGive( xMutex );
+    Attempt to take the semaphore, blocking indefinitely if the mutex is not
+    available immediately.  The call to xSemaphoreTake() will only return when
+    the semaphore has been successfully obtained so there is no need to check the
+    return value.  If any other delay period was used then the code must check
+    that xSemaphoreTake() returns pdTRUE before accessing the resource (in this
+    case standard out. */
+    xSemaphoreTake( xMutex, portMAX_DELAY );
+    {
+        /* The following line will only execute once the semaphore has been
+        successfully obtained - so standard out can be accessed freely. */
+        printf( "%s", pcString );
+        fflush( stdout );
+    }
+    xSemaphoreGive( xMutex );
 
-	/* Allow any key to stop the application running.  A real application that
-	actually used the key value should protect access to the keyboard too.  A
-	real application is very unlikely to have more than one task processing
-	key presses though! */
-	if( _kbhit() != 0 )
-	{
-		vTaskEndScheduler();
-	}
+    /* Allow any key to stop the application running.  A real application that
+    actually used the key value should protect access to the keyboard too.  A
+    real application is very unlikely to have more than one task processing
+    key presses though! */
+    if( _kbhit() != 0 )
+    {
+        vTaskEndScheduler();
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -155,26 +155,26 @@ static void prvPrintTask( void *pvParameters )
 char *pcStringToPrint;
 const TickType_t xSlowDownDelay = pdMS_TO_TICKS( 5UL );
 
-	/* Two instances of this task are created.  The string printed by the task
-	is passed into the task using the task's parameter.  The parameter is cast
-	to the required type. */
-	pcStringToPrint = ( char * ) pvParameters;
+    /* Two instances of this task are created.  The string printed by the task
+    is passed into the task using the task's parameter.  The parameter is cast
+    to the required type. */
+    pcStringToPrint = ( char * ) pvParameters;
 
-	for( ;; )
-	{
-		/* Print out the string using the newly defined function. */
-		prvNewPrintString( pcStringToPrint );
+    for( ;; )
+    {
+        /* Print out the string using the newly defined function. */
+        prvNewPrintString( pcStringToPrint );
 
-		/* Wait a pseudo random time.  Note that rand() is not necessarily
-		re-entrant, but in this case it does not really matter as the code does
-		not care what value is returned.  In a more secure application a version
-		of rand() that is known to be re-entrant should be used - or calls to
-		rand() should be protected using a critical section. */
-		vTaskDelay( rand() % xMaxBlockTimeTicks );
+        /* Wait a pseudo random time.  Note that rand() is not necessarily
+        re-entrant, but in this case it does not really matter as the code does
+        not care what value is returned.  In a more secure application a version
+        of rand() that is known to be re-entrant should be used - or calls to
+        rand() should be protected using a critical section. */
+        vTaskDelay( rand() % xMaxBlockTimeTicks );
 
-		/* Just to ensure the scrolling is not too fast! */
-		vTaskDelay( xSlowDownDelay );
-	}
+        /* Just to ensure the scrolling is not too fast! */
+        vTaskDelay( xSlowDownDelay );
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example021/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example021/main.c
@@ -86,9 +86,9 @@ static void prvStdioGatekeeperTask( void *pvParameters );
 gatekeeper. */
 static const char *pcStringsToPrint[] =
 {
-	"Task 1 ****************************************************\r\n",
-	"Task 2 ----------------------------------------------------\r\n",
-	"Message printed from the tick hook interrupt ##############\r\n"
+    "Task 1 ****************************************************\r\n",
+    "Task 2 ----------------------------------------------------\r\n",
+    "Message printed from the tick hook interrupt ##############\r\n"
 };
 
 /*-----------------------------------------------------------*/
@@ -103,33 +103,33 @@ const TickType_t xMaxBlockTimeTicks = 0x20;
 int main( void )
 {
     /* Before a queue is used it must be explicitly created.  The queue is created
-	to hold a maximum of 5 character pointers. */
+    to hold a maximum of 5 character pointers. */
     xPrintQueue = xQueueCreate( 5, sizeof( char * ) );
 
-	/* Check the queue was created successfully. */
-	if( xPrintQueue != NULL )
-	{
-		/* Create two instances of the tasks that send messages to the gatekeeper.
-		The	index to the string they attempt to write is passed in as the task
-		parameter (4th parameter to xTaskCreate()).  The tasks are created at
-		different priorities so some pre-emption will occur. */
-		xTaskCreate( prvPrintTask, "Print1", 1000, ( void * ) 0, 1, NULL );
-		xTaskCreate( prvPrintTask, "Print2", 1000, ( void * ) 1, 2, NULL );
+    /* Check the queue was created successfully. */
+    if( xPrintQueue != NULL )
+    {
+        /* Create two instances of the tasks that send messages to the gatekeeper.
+        The    index to the string they attempt to write is passed in as the task
+        parameter (4th parameter to xTaskCreate()).  The tasks are created at
+        different priorities so some pre-emption will occur. */
+        xTaskCreate( prvPrintTask, "Print1", 1000, ( void * ) 0, 1, NULL );
+        xTaskCreate( prvPrintTask, "Print2", 1000, ( void * ) 1, 2, NULL );
 
-		/* Create the gatekeeper task.  This is the only task that is permitted
-		to access standard out. */
-		xTaskCreate( prvStdioGatekeeperTask, "Gatekeeper", 1000, NULL, 0, NULL );
+        /* Create the gatekeeper task.  This is the only task that is permitted
+        to access standard out. */
+        xTaskCreate( prvStdioGatekeeperTask, "Gatekeeper", 1000, NULL, 0, NULL );
 
-		/* Start the scheduler so the created tasks start executing. */
-		vTaskStartScheduler();
-	}
+        /* Start the scheduler so the created tasks start executing. */
+        vTaskStartScheduler();
+    }
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -137,24 +137,24 @@ static void prvStdioGatekeeperTask( void *pvParameters )
 {
 char *pcMessageToPrint;
 
-	/* This is the only task that is allowed to write to the terminal output.
-	Any other task wanting to write to the output does not access the terminal
-	directly, but instead sends the output to this task.  As only one task
-	writes to standard out there are no mutual exclusion or serialization issues
-	to consider within this task itself. */
-	for( ;; )
-	{
-		/* Wait for a message to arrive. */
-		xQueueReceive( xPrintQueue, &pcMessageToPrint, portMAX_DELAY );
+    /* This is the only task that is allowed to write to the terminal output.
+    Any other task wanting to write to the output does not access the terminal
+    directly, but instead sends the output to this task.  As only one task
+    writes to standard out there are no mutual exclusion or serialization issues
+    to consider within this task itself. */
+    for( ;; )
+    {
+        /* Wait for a message to arrive. */
+        xQueueReceive( xPrintQueue, &pcMessageToPrint, portMAX_DELAY );
 
-		/* There is no need to check the return	value as the task will block
-		indefinitely and only run again when a message has arrived.  When the
-		next line is executed there will be a message to be output. */
-		printf( "%s", pcMessageToPrint );
-		fflush( stdout );
+        /* There is no need to check the return    value as the task will block
+        indefinitely and only run again when a message has arrived.  When the
+        next line is executed there will be a message to be output. */
+        printf( "%s", pcMessageToPrint );
+        fflush( stdout );
 
-		/* Now simply go back to wait for the next message. */
-	}
+        /* Now simply go back to wait for the next message. */
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -162,19 +162,19 @@ void vApplicationTickHook( void )
 {
 static int iCount = 0;
 
-	/* Print out a message every 200 ticks.  The message is not written out
-	directly, but sent to the gatekeeper task. */
-	iCount++;
-	if( iCount >= 200 )
-	{
-		/* In this case the last parameter (xHigherPriorityTaskWoken) is not
-		actually used and is set to NULL. */
-		xQueueSendToFrontFromISR( xPrintQueue, &( pcStringsToPrint[ 2 ] ), NULL );
+    /* Print out a message every 200 ticks.  The message is not written out
+    directly, but sent to the gatekeeper task. */
+    iCount++;
+    if( iCount >= 200 )
+    {
+        /* In this case the last parameter (xHigherPriorityTaskWoken) is not
+        actually used and is set to NULL. */
+        xQueueSendToFrontFromISR( xPrintQueue, &( pcStringsToPrint[ 2 ] ), NULL );
 
-		/* Reset the count ready to print out the string again in 200 ticks
-		time. */
-		iCount = 0;
-	}
+        /* Reset the count ready to print out the string again in 200 ticks
+        time. */
+        iCount = 0;
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -182,26 +182,28 @@ static void prvPrintTask( void *pvParameters )
 {
 int iIndexToString;
 
-	/* Two instances of this task are created so the index to the string the task
-	will send to the gatekeeper task is passed in the task parameter.  Cast this
-	to the required type. */
-	iIndexToString = ( int ) pvParameters;
+    /* Two instances of this task are created so the index to the string the task
+    will send to the gatekeeper task is passed in the task parameter.  Cast this
+    to the required type. */
+    iIndexToString = ( int ) pvParameters;
 
-	for( ;; )
-	{
-		/* Print out the string, not directly but by passing the string to the
-		gatekeeper task on the queue.  The queue is created before the scheduler is
-		started so will already exist by the time this task executes.  A block time
-		is not specified as there should always be space in the queue. */
-		xQueueSendToBack( xPrintQueue, &( pcStringsToPrint[ iIndexToString ] ), 0 );
+    for( ;; )
+    {
+        /* Print out the string, not directly but by passing the string to the
+        gatekeeper task on the queue.  The queue is created before the scheduler 
+        is started so will already exist by the time this task executes.  A 
+        block time is not specified as there should always be space in the queue.
+        Posts to the queue that are not successful may pass unnoticed as the 
+        return value of the queue send function is not checked. */
+        xQueueSendToBack( xPrintQueue, &( pcStringsToPrint[ iIndexToString ] ), 0 );
 
-		/* Wait a pseudo random time.  Note that rand() is not necessarily
-		re-entrant, but in this case it does not really matter as the code does
-		not care what value is returned.  In a more secure application a version
-		of rand() that is known to be re-entrant should be used - or calls to
-		rand() should be protected using a critical section. */
-		vTaskDelay( ( rand() % xMaxBlockTimeTicks ) );
-	}
+        /* Wait a pseudo random time.  Note that rand() is not necessarily
+        re-entrant, but in this case it does not really matter as the code does
+        not care what value is returned.  In a more secure application a version
+        of rand() that is known to be re-entrant should be used - or calls to
+        rand() should be protected using a critical section. */
+        vTaskDelay( ( rand() % xMaxBlockTimeTicks ) );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -223,21 +225,21 @@ optimised away and therefore unavailable when viewed in the debugger. */
 volatile uint32_t ulLineNumber = ulLine, ulSetNonZeroInDebuggerToReturn = 0;
 volatile const char * const pcFileName = pcFile;
 
-	taskENTER_CRITICAL();
-	{
-		while( ulSetNonZeroInDebuggerToReturn == 0 )
-		{
-			/* If you want to set out of this function in the debugger to see
-			the	assert() location then set ulSetNonZeroInDebuggerToReturn to a
-			non-zero value. */
-		}
-	}
-	taskEXIT_CRITICAL();
+    taskENTER_CRITICAL();
+    {
+        while( ulSetNonZeroInDebuggerToReturn == 0 )
+        {
+            /* If you want to set out of this function in the debugger to see
+            the    assert() location then set ulSetNonZeroInDebuggerToReturn to a
+            non-zero value. */
+        }
+    }
+    taskEXIT_CRITICAL();
 
-	/* Remove the potential for compiler warnings issued because the variables
-	are set but not subsequently referenced. */
-	( void ) pcFileName;
-	( void ) ulLineNumber;
+    /* Remove the potential for compiler warnings issued because the variables
+    are set but not subsequently referenced. */
+    ( void ) pcFileName;
+    ( void ) ulLineNumber;
 }
 /*-----------------------------------------------------------*/
 
@@ -247,17 +249,17 @@ this example as to include it would result in multiple definitions of the tick
 hook function. */
 void vApplicationMallocFailedHook( void )
 {
-	/* vApplicationMallocFailedHook() will only be called if
-	configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
-	function that will get called if a call to pvPortMalloc() fails.
-	pvPortMalloc() is called internally by the kernel whenever a task, queue,
-	timer, event group, or semaphore is created.  It is also called by various
-	parts of the demo application.  If heap_1.c, heap_2.c or heap_4.c are used,
-	then the size of the heap available to pvPortMalloc() is defined by
-	configTOTAL_HEAP_SIZE in FreeRTOSConfig.h, and the xPortGetFreeHeapSize()
-	API function can be used to query the size of free heap space that remains.
-	More information is provided in the book text. */
-	vAssertCalled( __LINE__, __FILE__ );
+    /* vApplicationMallocFailedHook() will only be called if
+    configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
+    function that will get called if a call to pvPortMalloc() fails.
+    pvPortMalloc() is called internally by the kernel whenever a task, queue,
+    timer, event group, or semaphore is created.  It is also called by various
+    parts of the demo application.  If heap_1.c, heap_2.c or heap_4.c are used,
+    then the size of the heap available to pvPortMalloc() is defined by
+    configTOTAL_HEAP_SIZE in FreeRTOSConfig.h, and the xPortGetFreeHeapSize()
+    API function can be used to query the size of free heap space that remains.
+    More information is provided in the book text. */
+    vAssertCalled( __LINE__, __FILE__ );
 }
 /*-----------------------------------------------------------*/
 

--- a/examples/Win32-simulator-MSVC/Examples/Example022/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example022/main.c
@@ -75,12 +75,12 @@
 /* The number of the simulated interrupt used in this example.  Numbers 0 to 2
 are used by the FreeRTOS Windows port itself, so 3 is the first number available
 to the application. */
-#define mainINTERRUPT_NUMBER	3
+#define mainINTERRUPT_NUMBER    3
 
 /* Definitions for the event bits in the event group. */
-#define mainFIRST_TASK_BIT	( 1UL << 0UL ) /* Event bit 0, which is set by a task. */
-#define mainSECOND_TASK_BIT	( 1UL << 1UL ) /* Event bit 1, which is set by a task. */
-#define mainISR_BIT			( 1UL << 2UL ) /* Event bit 2, which is set by an ISR. */
+#define mainFIRST_TASK_BIT    ( 1UL << 0UL ) /* Event bit 0, which is set by a task. */
+#define mainSECOND_TASK_BIT    ( 1UL << 1UL ) /* Event bit 1, which is set by a task. */
+#define mainISR_BIT            ( 1UL << 2UL ) /* Event bit 2, which is set by an ISR. */
 
 /* The tasks to be created. */
 static void vIntegerGenerator( void *pvParameters );
@@ -102,35 +102,35 @@ EventGroupHandle_t xEventGroup;
 
 int main( void )
 {
-	/* Before an event group can be used it must first be created. */
-	xEventGroup = xEventGroupCreate();
+    /* Before an event group can be used it must first be created. */
+    xEventGroup = xEventGroupCreate();
 
-	/* Create the task that sets event bits in the event group. */
-	xTaskCreate( vEventBitSettingTask, "BitSetter", 1000, NULL, 1, NULL );
+    /* Create the task that sets event bits in the event group. */
+    xTaskCreate( vEventBitSettingTask, "BitSetter", 1000, NULL, 1, NULL );
 
-	/* Create the task that waits for event bits to get set in the event
-	group. */
-	xTaskCreate( vEventBitReadingTask, "BitReader", 1000, NULL, 2, NULL );
+    /* Create the task that waits for event bits to get set in the event
+    group. */
+    xTaskCreate( vEventBitReadingTask, "BitReader", 1000, NULL, 2, NULL );
 
-	/* Create the task that is used to periodically generate a software
-	interrupt. */
-	xTaskCreate( vIntegerGenerator, "IntGen", 1000, NULL, 3, NULL );
+    /* Create the task that is used to periodically generate a software
+    interrupt. */
+    xTaskCreate( vIntegerGenerator, "IntGen", 1000, NULL, 3, NULL );
 
-	/* Install the handler for the software interrupt.  The syntax necessary
-	to do this is dependent on the FreeRTOS port being used.  The syntax
-	shown here can only be used with the FreeRTOS Windows port, where such
-	interrupts are only simulated. */
-	vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulEventBitSettingISR );
+    /* Install the handler for the software interrupt.  The syntax necessary
+    to do this is dependent on the FreeRTOS port being used.  The syntax
+    shown here can only be used with the FreeRTOS Windows port, where such
+    interrupts are only simulated. */
+    vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulEventBitSettingISR );
 
-	/* Start the scheduler so the created tasks start executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created tasks start executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -138,25 +138,25 @@ static void vEventBitSettingTask( void *pvParameters )
 {
 const TickType_t xDelay200ms = pdMS_TO_TICKS( 200UL ), xDontBlock = 0;
 
-	for( ;; )
-	{
-		/* Delay for a short while before starting the next loop. */
-		vTaskDelay( xDelay200ms );
+    for( ;; )
+    {
+        /* Delay for a short while before starting the next loop. */
+        vTaskDelay( xDelay200ms );
 
-		/* Print out a message to say event bit 0 is about to be set by the
-		task, then set event bit 0. */
-		vPrintString( "Bit setting task -\t about to set bit 0.\r\n" );
-		xEventGroupSetBits( xEventGroup, mainFIRST_TASK_BIT );
+        /* Print out a message to say event bit 0 is about to be set by the
+        task, then set event bit 0. */
+        vPrintString( "Bit setting task -\t about to set bit 0.\r\n" );
+        xEventGroupSetBits( xEventGroup, mainFIRST_TASK_BIT );
 
-		/* Delay for a short while before setting the other bit set within this
-		task. */
-		vTaskDelay( xDelay200ms );
+        /* Delay for a short while before setting the other bit set within this
+        task. */
+        vTaskDelay( xDelay200ms );
 
-		/* Print out a message to say event bit 1 is about to be set by the
-		task, then set event bit 1. */
-		vPrintString( "Bit setting task -\t about to set bit 1.\r\n" );
-		xEventGroupSetBits( xEventGroup, mainSECOND_TASK_BIT );
-	}
+        /* Print out a message to say event bit 1 is about to be set by the
+        task, then set event bit 1. */
+        vPrintString( "Bit setting task -\t about to set bit 1.\r\n" );
+        xEventGroupSetBits( xEventGroup, mainSECOND_TASK_BIT );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -170,33 +170,33 @@ ISR's stack frame will not exist when the string is printed from the daemon
 task. */
 static const char *pcString = "Bit setting ISR -\t about to set bit 2.\r\n";
 
-	/* As always, xHigherPriorityTaskWoken is initialized to pdFALSE. */
-	xHigherPriorityTaskWoken = pdFALSE;
+    /* As always, xHigherPriorityTaskWoken is initialized to pdFALSE. */
+    xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Print out a message to say bit 2 is about to be set.  Messages cannot be
-	printed from an ISR, so defer the actual output to the RTOS daemon task by
-	pending a function call to run in the context of the RTOS daemon task. */
-	xTimerPendFunctionCallFromISR( vPrintStringFromDaemonTask, ( void * ) pcString, 0, &xHigherPriorityTaskWoken );
+    /* Print out a message to say bit 2 is about to be set.  Messages cannot be
+    printed from an ISR, so defer the actual output to the RTOS daemon task by
+    pending a function call to run in the context of the RTOS daemon task. */
+    xTimerPendFunctionCallFromISR( vPrintStringFromDaemonTask, ( void * ) pcString, 0, &xHigherPriorityTaskWoken );
 
-	/* Set bit 2 in the event group. */
-	xEventGroupSetBitsFromISR( xEventGroup, mainISR_BIT, &xHigherPriorityTaskWoken );
+    /* Set bit 2 in the event group. */
+    xEventGroupSetBitsFromISR( xEventGroup, mainISR_BIT, &xHigherPriorityTaskWoken );
 
-	/* xEventGroupSetBitsFromISR() writes to the timer command queue.  If
-	writing to the timer command queue results in the RTOS daemon task leaving
-	the Blocked state, and if the priority of the RTOS daemon task is higher
-	than the priority of the currently executing task (the task this interrupt
-	interrupted) then xHigherPriorityTaskWoken will have been set to pdTRUE
-	inside xEventGroupSetBitsFromISR().
+    /* xEventGroupSetBitsFromISR() writes to the timer command queue.  If
+    writing to the timer command queue results in the RTOS daemon task leaving
+    the Blocked state, and if the priority of the RTOS daemon task is higher
+    than the priority of the currently executing task (the task this interrupt
+    interrupted) then xHigherPriorityTaskWoken will have been set to pdTRUE
+    inside xEventGroupSetBitsFromISR().
 
-	xHigherPriorityTaskWoken is used as the parameter to portYIELD_FROM_ISR().
-	If xHigherPriorityTaskWoken equals pdTRUE then calling portYIELD_FROM_ISR()
+    xHigherPriorityTaskWoken is used as the parameter to portYIELD_FROM_ISR().
+    If xHigherPriorityTaskWoken equals pdTRUE then calling portYIELD_FROM_ISR()
     will request a context switch.  If xHigherPriorityTaskWoken is still pdFALSE
-	then calling portYIELD_FROM_ISR() will have no effect.
+    then calling portYIELD_FROM_ISR() will have no effect.
 
-	The implementation of portYIELD_FROM_ISR() used by the Windows port includes
-	a return statement, which is why this function does not explicitly return a
-	value. */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    The implementation of portYIELD_FROM_ISR() used by the Windows port includes
+    a return statement, which is why this function does not explicitly return a
+    value. */
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
@@ -205,51 +205,51 @@ static void vEventBitReadingTask( void *pvParameters )
 const EventBits_t xBitsToWaitFor = ( mainFIRST_TASK_BIT | mainSECOND_TASK_BIT | mainISR_BIT );
 EventBits_t xEventGroupValue;
 
-	for( ;; )
-	{
-		/* Block to wait for event bits to become set within the event group. */
-		xEventGroupValue = xEventGroupWaitBits( /* The event group to read. */
-												xEventGroup,
+    for( ;; )
+    {
+        /* Block to wait for event bits to become set within the event group. */
+        xEventGroupValue = xEventGroupWaitBits( /* The event group to read. */
+                                                xEventGroup,
 
-												/* Bits to test. */
-												xBitsToWaitFor,
+                                                /* Bits to test. */
+                                                xBitsToWaitFor,
 
-												/* Clear bits on exit if the
-												unblock condition is met. */
-												pdTRUE,
+                                                /* Clear bits on exit if the
+                                                unblock condition is met. */
+                                                pdTRUE,
 
-												/* Don't wait for all bits. */
-												pdFALSE,
+                                                /* Don't wait for all bits. */
+                                                pdFALSE,
 
-												/* Don't time out. */
-												portMAX_DELAY );
+                                                /* Don't time out. */
+                                                portMAX_DELAY );
 
-		/* Print a message for each bit that was set. */
-		if( ( xEventGroupValue & mainFIRST_TASK_BIT ) != 0 )
-		{
-			vPrintString( "Bit reading task -\t event bit 0 was set\r\n" );
-		}
+        /* Print a message for each bit that was set. */
+        if( ( xEventGroupValue & mainFIRST_TASK_BIT ) != 0 )
+        {
+            vPrintString( "Bit reading task -\t event bit 0 was set\r\n" );
+        }
 
-		if( ( xEventGroupValue & mainSECOND_TASK_BIT ) != 0 )
-		{
-			vPrintString( "Bit reading task -\t event bit 1 was set\r\n" );
-		}
+        if( ( xEventGroupValue & mainSECOND_TASK_BIT ) != 0 )
+        {
+            vPrintString( "Bit reading task -\t event bit 1 was set\r\n" );
+        }
 
-		if( ( xEventGroupValue & mainISR_BIT ) != 0 )
-		{
-			vPrintString( "Bit reading task -\t event bit 2 was set\r\n" );
-		}
+        if( ( xEventGroupValue & mainISR_BIT ) != 0 )
+        {
+            vPrintString( "Bit reading task -\t event bit 2 was set\r\n" );
+        }
 
-		vPrintString( "\r\n" );
-	}
+        vPrintString( "\r\n" );
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPrintStringFromDaemonTask( void *pvParameter1, uint32_t ulParameter2 )
 {
-	/* The string to print is passed into this function using the pvParameter1
-	parameter. */
-	vPrintString( ( const char * ) pvParameter1 );
+    /* The string to print is passed into this function using the pvParameter1
+    parameter. */
+    vPrintString( ( const char * ) pvParameter1 );
 }
 /*-----------------------------------------------------------*/
 
@@ -258,18 +258,18 @@ static void vIntegerGenerator( void *pvParameters )
 TickType_t xLastExecutionTime;
 const TickType_t xDelay500ms = pdMS_TO_TICKS( 500UL );
 
-	/* Initialize the variable used by the call to vTaskDelayUntil(). */
-	xLastExecutionTime = xTaskGetTickCount();
+    /* Initialize the variable used by the call to vTaskDelayUntil(). */
+    xLastExecutionTime = xTaskGetTickCount();
 
-	for( ;; )
-	{
-		/* This is a periodic task.  Block until it is time to run again.
-		The task will execute every 500ms. */
-		vTaskDelayUntil( &xLastExecutionTime, xDelay500ms );
+    for( ;; )
+    {
+        /* This is a periodic task.  Block until it is time to run again.
+        The task will execute every 500ms. */
+        vTaskDelayUntil( &xLastExecutionTime, xDelay500ms );
 
-		/* Generate the interrupt that will set a bit in the event group. */
-		vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
-	}
+        /* Generate the interrupt that will set a bit in the event group. */
+        vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example023/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example023/main.c
@@ -75,9 +75,9 @@
 #include "supporting_functions.h"
 
 /* Definitions for the event bits in the event group. */
-#define mainFIRST_TASK_BIT	( 1UL << 0UL ) /* Event bit 0, which is set by the first task. */
-#define mainSECOND_TASK_BIT	( 1UL << 1UL ) /* Event bit 1, which is set by the second task. */
-#define mainTHIRD_TASK_BIT	( 1UL << 2UL ) /* Event bit 2, which is set by the third task. */
+#define mainFIRST_TASK_BIT    ( 1UL << 0UL ) /* Event bit 0, which is set by the first task. */
+#define mainSECOND_TASK_BIT    ( 1UL << 1UL ) /* Event bit 1, which is set by the second task. */
+#define mainTHIRD_TASK_BIT    ( 1UL << 2UL ) /* Event bit 2, which is set by the third task. */
 
 /* Pseudo random number generation functions - implemented in this file as the
 MSVC rand() function has unexpected consequences. */
@@ -97,30 +97,30 @@ EventGroupHandle_t xEventGroup;
 
 int main( void )
 {
-	/* The tasks created in this example block for a random time.  The block
-	time is generated using rand() - seed the random number generator. */
-	prvSRand( ( uint32_t ) time( NULL ) );
+    /* The tasks created in this example block for a random time.  The block
+    time is generated using rand() - seed the random number generator. */
+    prvSRand( ( uint32_t ) time( NULL ) );
 
-	/* Before an event group can be used it must first be created. */
-	xEventGroup = xEventGroupCreate();
+    /* Before an event group can be used it must first be created. */
+    xEventGroup = xEventGroupCreate();
 
-	/* Create three instances of the task.  Each task is given a different name,
-	which is later printed out to give a visual indication of which task is
-	executing.  The event bit to use when the task reaches its synchronization
-	point is passed into the task using the task parameter. */
-	xTaskCreate( vSyncingTask, "Task 1", 1000, ( void * ) mainFIRST_TASK_BIT, 1, NULL );
-	xTaskCreate( vSyncingTask, "Task 2", 1000, ( void * ) mainSECOND_TASK_BIT, 1, NULL );
-	xTaskCreate( vSyncingTask, "Task 3", 1000, ( void * ) mainTHIRD_TASK_BIT, 1, NULL );
+    /* Create three instances of the task.  Each task is given a different name,
+    which is later printed out to give a visual indication of which task is
+    executing.  The event bit to use when the task reaches its synchronization
+    point is passed into the task using the task parameter. */
+    xTaskCreate( vSyncingTask, "Task 1", 1000, ( void * ) mainFIRST_TASK_BIT, 1, NULL );
+    xTaskCreate( vSyncingTask, "Task 2", 1000, ( void * ) mainSECOND_TASK_BIT, 1, NULL );
+    xTaskCreate( vSyncingTask, "Task 3", 1000, ( void * ) mainTHIRD_TASK_BIT, 1, NULL );
 
-	/* Start the scheduler so the created tasks start executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created tasks start executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -132,49 +132,49 @@ const TickType_t xMinDelay = pdMS_TO_TICKS( 200UL );
 TickType_t xDelayTime;
 EventBits_t uxThisTasksSyncBit;
 
-	/* Three instances of this task are created - each task uses a different
-	event bit in the synchronization.  The event bit to use by this task
-	instance is passed into the task using the task's parameter.  Store it in
-	the uxThisTasksSyncBit variable. */
-	uxThisTasksSyncBit = ( EventBits_t ) pvParameters;
+    /* Three instances of this task are created - each task uses a different
+    event bit in the synchronization.  The event bit to use by this task
+    instance is passed into the task using the task's parameter.  Store it in
+    the uxThisTasksSyncBit variable. */
+    uxThisTasksSyncBit = ( EventBits_t ) pvParameters;
 
-	for( ;; )
-	{
-		/* Simulate this task taking some time to perform an action by delaying
-		for a pseudo random time.  This prevents all three instances of this
-		task from reaching the synchronization point at the same time, and
-		allows the example's behavior to be observed more easily. */
-		xDelayTime = ( prvRand() % xMaxDelay ) + xMinDelay;
-		vTaskDelay( xDelayTime );
+    for( ;; )
+    {
+        /* Simulate this task taking some time to perform an action by delaying
+        for a pseudo random time.  This prevents all three instances of this
+        task from reaching the synchronization point at the same time, and
+        allows the example's behavior to be observed more easily. */
+        xDelayTime = ( prvRand() % xMaxDelay ) + xMinDelay;
+        vTaskDelay( xDelayTime );
 
-		/* Print out a message to show this task has reached its synchronization
-		point.  pcTaskGetTaskName() is an API function that returns the name
-		assigned to the task when the task was created. */
-		vPrintTwoStrings( pcTaskGetTaskName( NULL ), "reached sync point" );
+        /* Print out a message to show this task has reached its synchronization
+        point.  pcTaskGetTaskName() is an API function that returns the name
+        assigned to the task when the task was created. */
+        vPrintTwoStrings( pcTaskGetTaskName( NULL ), "reached sync point" );
 
-		/* Wait for all the tasks to have reached their respective
-		synchronization points. */
-		xEventGroupSync( /* The event group used to synchronize. */
-						 xEventGroup,
+        /* Wait for all the tasks to have reached their respective
+        synchronization points. */
+        xEventGroupSync( /* The event group used to synchronize. */
+                         xEventGroup,
 
-						 /* The bit set by this task to indicate it has reached
-						 the synchronization point. */
-						 uxThisTasksSyncBit,
+                         /* The bit set by this task to indicate it has reached
+                         the synchronization point. */
+                         uxThisTasksSyncBit,
 
-						 /* The bits to wait for, one bit for each task taking
-						 part in the synchronization. */
-						 uxAllSyncBits,
+                         /* The bits to wait for, one bit for each task taking
+                         part in the synchronization. */
+                         uxAllSyncBits,
 
-						 /* Wait indefinitely for all three tasks to reach the
-						 synchronization point. */
-						 portMAX_DELAY );
+                         /* Wait indefinitely for all three tasks to reach the
+                         synchronization point. */
+                         portMAX_DELAY );
 
-		/* Print out a message to show this task has passed its synchronization
-		point.  As an indefinite delay was used the following line will only be
-		reached after all the tasks reached their respective synchronization
-		points. */
-		vPrintTwoStrings( pcTaskGetTaskName( NULL ), "exited sync point" );
-	}
+        /* Print out a message to show this task has passed its synchronization
+        point.  As an indefinite delay was used the following line will only be
+        reached after all the tasks reached their respective synchronization
+        points. */
+        vPrintTwoStrings( pcTaskGetTaskName( NULL ), "exited sync point" );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -183,20 +183,20 @@ static uint32_t prvRand( void )
 const uint32_t ulMultiplier = 0x015a4e35UL, ulIncrement = 1UL;
 uint32_t ulReturn;
 
-	/* Utility function to generate a pseudo random number as the MSVC rand()
-	function has unexpected consequences. */
-	taskENTER_CRITICAL();
-		ulNextRand = ( ulMultiplier * ulNextRand ) + ulIncrement;
-		ulReturn = ( ulNextRand >> 16UL ) & 0x7fffUL;
-	taskEXIT_CRITICAL();
-	return ulReturn;
+    /* Utility function to generate a pseudo random number as the MSVC rand()
+    function has unexpected consequences. */
+    taskENTER_CRITICAL();
+        ulNextRand = ( ulMultiplier * ulNextRand ) + ulIncrement;
+        ulReturn = ( ulNextRand >> 16UL ) & 0x7fffUL;
+    taskEXIT_CRITICAL();
+    return ulReturn;
 }
 /*-----------------------------------------------------------*/
 
 static void prvSRand( uint32_t ulSeed )
 {
-	/* Utility function to seed the pseudo random number generator. */
-	ulNextRand = ulSeed;
+    /* Utility function to seed the pseudo random number generator. */
+    ulNextRand = ulSeed;
 }
 /*-----------------------------------------------------------*/
 

--- a/examples/Win32-simulator-MSVC/Examples/Example024/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example024/main.c
@@ -74,7 +74,7 @@
 /* The number of the simulated interrupt used in this example.  Numbers 0 to 2
 are used by the FreeRTOS Windows port itself, so 3 is the first number available
 to the application. */
-#define mainINTERRUPT_NUMBER	3
+#define mainINTERRUPT_NUMBER    3
 
 /* The tasks to be created. */
 static void vHandlerTask( void *pvParameters );
@@ -94,34 +94,34 @@ static TaskHandle_t xHandlerTask = NULL;
 
 int main( void )
 {
-	/* Create the 'handler' task, which is the task to which interrupt
-	processing is deferred, and so is the task that will be synchronized
-	with the interrupt.  The handler task is created with a high priority to
-	ensure it runs immediately after the interrupt exits.  In this case a
-	priority of 3 is chosen.  The handle of the task is saved for use by the
-	ISR. */
-	xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, &xHandlerTask );
+    /* Create the 'handler' task, which is the task to which interrupt
+    processing is deferred, and so is the task that will be synchronized
+    with the interrupt.  The handler task is created with a high priority to
+    ensure it runs immediately after the interrupt exits.  In this case a
+    priority of 3 is chosen.  The handle of the task is saved for use by the
+    ISR. */
+    xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, &xHandlerTask );
 
-	/* Create the task that will periodically generate a software interrupt.
-	This is created with a priority below the handler task to ensure it will
-	get preempted each time the handler task exits the Blocked state. */
-	xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
+    /* Create the task that will periodically generate a software interrupt.
+    This is created with a priority below the handler task to ensure it will
+    get preempted each time the handler task exits the Blocked state. */
+    xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
 
-	/* Install the handler for the software interrupt.  The syntax necessary
-	to do this is dependent on the FreeRTOS port being used.  The syntax
-	shown here can only be used with the FreeRTOS Windows port, where such
-	interrupts are only simulated. */
-	vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
+    /* Install the handler for the software interrupt.  The syntax necessary
+    to do this is dependent on the FreeRTOS port being used.  The syntax
+    shown here can only be used with the FreeRTOS Windows port, where such
+    interrupts are only simulated. */
+    vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
-	/* Start the scheduler so the created tasks start executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created tasks start executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -132,30 +132,30 @@ time between events. */
 const TickType_t xMaxExpectedBlockTime = xInterruptFrequency + pdMS_TO_TICKS( 10 );
 uint32_t ulEventsToProcess;
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* Wait to receive a notification sent directly to this task from the
-		interrupt handler. */
-		ulEventsToProcess = ulTaskNotifyTake( pdTRUE, xMaxExpectedBlockTime );
-		if( ulEventsToProcess != 0 )
-		{
-			/* To get here at least one event must have occurred.  Loop here
-			until all the pending events have been processed (in this case, just
-			print out a message for each event). */
-			while( ulEventsToProcess > 0 )
-			{
-				vPrintString( "Handler task - Processing event.\r\n" );
-				ulEventsToProcess--;
-			}
-		}
-		else
-		{
-			/* If this part of the function is reached then an interrupt did not
-			arrive within the expected time, and (in a real application) it may
-			be necessary to perform some error recovery operations. */
-		}
-	}
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* Wait to receive a notification sent directly to this task from the
+        interrupt handler. */
+        ulEventsToProcess = ulTaskNotifyTake( pdTRUE, xMaxExpectedBlockTime );
+        if( ulEventsToProcess != 0 )
+        {
+            /* To get here at least one event must have occurred.  Loop here
+            until all the pending events have been processed (in this case, just
+            print out a message for each event). */
+            while( ulEventsToProcess > 0 )
+            {
+                vPrintString( "Handler task - Processing event.\r\n" );
+                ulEventsToProcess--;
+            }
+        }
+        else
+        {
+            /* If this part of the function is reached then an interrupt did not
+            arrive within the expected time, and (in a real application) it may
+            be necessary to perform some error recovery operations. */
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -163,54 +163,54 @@ static uint32_t ulExampleInterruptHandler( void )
 {
 BaseType_t xHigherPriorityTaskWoken;
 
-	/* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
-	it will get set to pdTRUE inside the interrupt safe API function if a
-	context switch is required. */
-	xHigherPriorityTaskWoken = pdFALSE;
+    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
+    it will get set to pdTRUE inside the interrupt safe API function if a
+    context switch is required. */
+    xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Send a notification directly to the handler task. */
-	vTaskNotifyGiveFromISR( /* The handle of the task to which the notification
-							is being sent.  The handle was saved when the task
-							was created. */
-							xHandlerTask,
+    /* Send a notification directly to the handler task. */
+    vTaskNotifyGiveFromISR( /* The handle of the task to which the notification
+                            is being sent.  The handle was saved when the task
+                            was created. */
+                            xHandlerTask,
 
-							/* xHigherPriorityTaskWoken is used in the usual
-							way. */
-							&xHigherPriorityTaskWoken );
+                            /* xHigherPriorityTaskWoken is used in the usual
+                            way. */
+                            &xHigherPriorityTaskWoken );
 
-	/* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
-	xHigherPriorityTaskWoken was set to pdTRUE inside vTaskNotifyGiveFromISR()
-	then calling portYIELD_FROM_ISR() will request a context switch.  If
-	xHigherPriorityTaskWoken is still pdFALSE then calling
-	portYIELD_FROM_ISR() will have no effect.  The implementation of
-	portYIELD_FROM_ISR() used by the Windows port includes a return statement,
-	which is why this function does not explicitly return a value. */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
+    xHigherPriorityTaskWoken was set to pdTRUE inside vTaskNotifyGiveFromISR()
+    then calling portYIELD_FROM_ISR() will request a context switch.  If
+    xHigherPriorityTaskWoken is still pdFALSE then calling
+    portYIELD_FROM_ISR() will have no effect.  The implementation of
+    portYIELD_FROM_ISR() used by the Windows port includes a return statement,
+    which is why this function does not explicitly return a value. */
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
 static void vPeriodicTask( void *pvParameters )
 {
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* This task is just used to 'simulate' an interrupt.  This is done by
-		periodically generating a simulated software interrupt.  Block until it
-		is time to generate the software interrupt again. */
-		vTaskDelay( xInterruptFrequency );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* This task is just used to 'simulate' an interrupt.  This is done by
+        periodically generating a simulated software interrupt.  Block until it
+        is time to generate the software interrupt again. */
+        vTaskDelay( xInterruptFrequency );
 
-		/* Generate the interrupt, printing a message both before and after
-		the interrupt has been generated so the sequence of execution is evident
-		from the output.
+        /* Generate the interrupt, printing a message both before and after
+        the interrupt has been generated so the sequence of execution is evident
+        from the output.
 
-		The syntax used to generate a software interrupt is dependent on the
-		FreeRTOS port being used.  The syntax used below can only be used with
-		the FreeRTOS Windows port, in which such interrupts are only
-		simulated. */
-		vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
-		vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
-		vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
-	}
+        The syntax used to generate a software interrupt is dependent on the
+        FreeRTOS port being used.  The syntax used below can only be used with
+        the FreeRTOS Windows port, in which such interrupts are only
+        simulated. */
+        vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
+        vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
+        vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
+    }
 }
 
 

--- a/examples/Win32-simulator-MSVC/Examples/Example025/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example025/main.c
@@ -74,7 +74,7 @@
 /* The number of the simulated interrupt used in this example.  Numbers 0 to 2
 are used by the FreeRTOS Windows port itself, so 3 is the first number available
 to the application. */
-#define mainINTERRUPT_NUMBER	3
+#define mainINTERRUPT_NUMBER    3
 
 /* The tasks to be created. */
 static void vHandlerTask( void *pvParameters );
@@ -94,34 +94,34 @@ static TaskHandle_t xHandlerTask = NULL;
 
 int main( void )
 {
-	/* Create the 'handler' task, which is the task to which interrupt
-	processing is deferred, and so is the task that will be synchronized
-	with the interrupt.  The handler task is created with a high priority to
-	ensure it runs immediately after the interrupt exits.  In this case a
-	priority of 3 is chosen.  The handle of the task is saved for use by the
-	ISR. */
-	xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, &xHandlerTask );
+    /* Create the 'handler' task, which is the task to which interrupt
+    processing is deferred, and so is the task that will be synchronized
+    with the interrupt.  The handler task is created with a high priority to
+    ensure it runs immediately after the interrupt exits.  In this case a
+    priority of 3 is chosen.  The handle of the task is saved for use by the
+    ISR. */
+    xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, &xHandlerTask );
 
-	/* Create the task that will periodically generate a software interrupt.
-	This is created with a priority below the handler task to ensure it will
-	get preempted each time the handler task exits the Blocked state. */
-	xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
+    /* Create the task that will periodically generate a software interrupt.
+    This is created with a priority below the handler task to ensure it will
+    get preempted each time the handler task exits the Blocked state. */
+    xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
 
-	/* Install the handler for the software interrupt.  The syntax necessary
-	to do this is dependent on the FreeRTOS port being used.  The syntax
-	shown here can only be used with the FreeRTOS Windows port, where such
-	interrupts are only simulated. */
-	vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
+    /* Install the handler for the software interrupt.  The syntax necessary
+    to do this is dependent on the FreeRTOS port being used.  The syntax
+    shown here can only be used with the FreeRTOS Windows port, where such
+    interrupts are only simulated. */
+    vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
-	/* Start the scheduler so the created tasks start executing. */
-	vTaskStartScheduler();
+    /* Start the scheduler so the created tasks start executing. */
+    vTaskStartScheduler();
 
-	/* The following line should never be reached because vTaskStartScheduler()
-	will only return if there was not enough FreeRTOS heap memory available to
-	create the Idle and (if configured) Timer tasks.  Heap management, and
-	techniques for trapping heap exhaustion, are described in the book text. */
-	for( ;; );
-	return 0;
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    for( ;; );
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -131,26 +131,26 @@ static void vHandlerTask( void *pvParameters )
 time between events. */
 const TickType_t xMaxExpectedBlockTime = xInterruptFrequency + pdMS_TO_TICKS( 10 );
 
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* Wait to receive a notification sent directly to this task from the
-		interrupt handler.  The xClearCountOnExit parameter is now pdFALSE, so
-		the task's notification will be decremented when ulTaskNotifyTake()
-		returns having received a notification. */
-		if( ulTaskNotifyTake( pdFALSE, xMaxExpectedBlockTime ) != 0 )
-		{
-			/* To get here the event must have occurred.  Process the event (in
-			this case just print out a message). */
-			vPrintString( "Handler task - Processing event.\r\n" );
-		}
-		else
-		{
-			/* If this part of the function is reached then an interrupt did not
-			arrive within the expected time, and (in a real application) it may
-			be necessary to perform some error recovery operations. */
-		}
-	}
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* Wait to receive a notification sent directly to this task from the
+        interrupt handler.  The xClearCountOnExit parameter is now pdFALSE, so
+        the task's notification will be decremented when ulTaskNotifyTake()
+        returns having received a notification. */
+        if( ulTaskNotifyTake( pdFALSE, xMaxExpectedBlockTime ) != 0 )
+        {
+            /* To get here the event must have occurred.  Process the event (in
+            this case just print out a message). */
+            vPrintString( "Handler task - Processing event.\r\n" );
+        }
+        else
+        {
+            /* If this part of the function is reached then an interrupt did not
+            arrive within the expected time, and (in a real application) it may
+            be necessary to perform some error recovery operations. */
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -158,52 +158,52 @@ static uint32_t ulExampleInterruptHandler( void )
 {
 BaseType_t xHigherPriorityTaskWoken;
 
-	/* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
-	it will get set to pdTRUE inside the interrupt safe API function if a
-	context switch is required. */
-	xHigherPriorityTaskWoken = pdFALSE;
+    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE as
+    it will get set to pdTRUE inside the interrupt safe API function if a
+    context switch is required. */
+    xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Send a notification to the handler task multiple times.  The first will
-	unblock the task, the following 'gives' are to demonstrate that the
-	receiving task's notification value is being used to latch events - allowing
-	the task to process the events in turn. */
-	vTaskNotifyGiveFromISR( xHandlerTask, &xHigherPriorityTaskWoken );
-	vTaskNotifyGiveFromISR( xHandlerTask, &xHigherPriorityTaskWoken );
-	vTaskNotifyGiveFromISR( xHandlerTask, &xHigherPriorityTaskWoken );
+    /* Send a notification to the handler task multiple times.  The first will
+    unblock the task, the following 'gives' are to demonstrate that the
+    receiving task's notification value is being used to latch events - allowing
+    the task to process the events in turn. */
+    vTaskNotifyGiveFromISR( xHandlerTask, &xHigherPriorityTaskWoken );
+    vTaskNotifyGiveFromISR( xHandlerTask, &xHigherPriorityTaskWoken );
+    vTaskNotifyGiveFromISR( xHandlerTask, &xHigherPriorityTaskWoken );
 
-	/* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
-	xHigherPriorityTaskWoken was set to pdTRUE inside vTaskNotifyGiveFromISR()
-	then calling portYIELD_FROM_ISR() will request a context switch.  If
-	xHigherPriorityTaskWoken is still pdFALSE then calling
-	portYIELD_FROM_ISR() will have no effect.  The implementation of
-	portYIELD_FROM_ISR() used by the Windows port includes a return statement,
-	which is why this function does not explicitly return a value. */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().  If
+    xHigherPriorityTaskWoken was set to pdTRUE inside vTaskNotifyGiveFromISR()
+    then calling portYIELD_FROM_ISR() will request a context switch.  If
+    xHigherPriorityTaskWoken is still pdFALSE then calling
+    portYIELD_FROM_ISR() will have no effect.  The implementation of
+    portYIELD_FROM_ISR() used by the Windows port includes a return statement,
+    which is why this function does not explicitly return a value. */
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
 static void vPeriodicTask( void *pvParameters )
 {
-	/* As per most tasks, this task is implemented within an infinite loop. */
-	for( ;; )
-	{
-		/* This task is just used to 'simulate' an interrupt.  This is done by
-		periodically generating a simulated software interrupt.  Block until it
-		is time to generate the software interrupt again. */
-		vTaskDelay( xInterruptFrequency );
+    /* As per most tasks, this task is implemented within an infinite loop. */
+    for( ;; )
+    {
+        /* This task is just used to 'simulate' an interrupt.  This is done by
+        periodically generating a simulated software interrupt.  Block until it
+        is time to generate the software interrupt again. */
+        vTaskDelay( xInterruptFrequency );
 
-		/* Generate the interrupt, printing a message both before and after
-		the interrupt has been generated so the sequence of execution is evident
-		from the output.
+        /* Generate the interrupt, printing a message both before and after
+        the interrupt has been generated so the sequence of execution is evident
+        from the output.
 
-		The syntax used to generate a software interrupt is dependent on the
-		FreeRTOS port being used.  The syntax used below can only be used with
-		the FreeRTOS Windows port, in which such interrupts are only
-		simulated. */
-		vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
-		vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
-		vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
-	}
+        The syntax used to generate a software interrupt is dependent on the
+        FreeRTOS port being used.  The syntax used below can only be used with
+        the FreeRTOS Windows port, in which such interrupts are only
+        simulated. */
+        vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
+        vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
+        vPrintString( "Periodic task - Interrupt generated.\r\n\r\n\r\n" );
+    }
 }
 
 


### PR DESCRIPTION
This PR fixes formatting in the examples folder and removes compiler warning due to unused parameters , and fixes API in the following examples.