### PR TITLE
Add table for FreeRTOS scheduling algorithm configuration

### DIFF
--- a/ch04.md
+++ b/ch04.md
@@ -2159,7 +2159,7 @@ scheduling algorithm does not guarantee time is shared equally between
 tasks of equal priority, only that *Ready* state tasks of equal priority
 enter the *Running* state in turn.
 
-<a name="tbl5" title="Table 5 The FreeRTOSConfig.h settings that configure the kernel to use various scheduling algorithms"></a>
+<a name="tbl5" title="Table 5 The FreeRTOSConfig.h settings to configure the kernel scheduling algorithms"></a>
 
 ***
 | Scheduling Algorithm            | Prioritized | `configUSE_PREEMPTION` | `configUSE_TIME_SLICING` |
@@ -2168,7 +2168,7 @@ enter the *Running* state in turn.
 | Preemptive Without Time Slicing | Yes         | 1 | 0   |
 | Co-Operative                    | No          | 0 | Any |
 
-***Table 5*** *The FreeRTOSConfig.h settings that configure the kernel to use various scheduling algorithms*
+***Table 5*** *The FreeRTOSConfig.h settings to configure the kernel scheduling algorithms*
 * * *
 
 ### 4.12.3 Prioritized Preemptive Scheduling with Time Slicing

--- a/ch04.md
+++ b/ch04.md
@@ -1319,25 +1319,25 @@ observed behavior given by the execution sequence shown in Figure 4.12.
 Continuous task 2 running
 Continuous task 2 running
 Periodic task is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 2 is running
-Continuous task 2 is running
-Continuous task 2 is running
-Continuous task 2 is running
-Continuous task 2 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
-Continuous task 1 is running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 2 running
+Continuous task 2 running
+Continuous task 2 running
+Continuous task 2 running
+Continuous task 2 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
+Continuous task 1 running
 Periodic task is running
 Continuous task 2 running
 Continuous task 2 running
@@ -2159,15 +2159,21 @@ scheduling algorithm does not guarantee time is shared equally between
 tasks of equal priority, only that *Ready* state tasks of equal priority
 enter the *Running* state in turn.
 
+<a name="tbl5" title="Table 5 The FreeRTOSConfig.h settings that configure the kernel to use various scheduling algorithms"></a>
+
+***
 | Scheduling Algorithm            | Prioritized | `configUSE_PREEMPTION` | `configUSE_TIME_SLICING` |
 |---------------------------------|-------------|------------------------|--------------------------|
 | Preemptive With Time Slicing    | Yes         | 1 | 1   |
 | Preemptive Without Time Slicing | Yes         | 1 | 0   |
 | Co-Operative                    | No          | 0 | Any |
 
+***Table 5*** *The FreeRTOSConfig.h settings that configure the kernel to use various scheduling algorithms*
+* * *
+
 ### 4.12.3 Prioritized Preemptive Scheduling with Time Slicing
 
-The configuration shown in the table below sets the FreeRTOS scheduler to use a
+The configuration shown in the Table 5 sets the FreeRTOS scheduler to use a
 scheduling algorithm called 'Fixed Priority Preemptive Scheduling with
 Time Slicing', which is the scheduling algorithm used by most small RTOS
 applications, and the algorithm used by all the examples presented in
@@ -2345,7 +2351,7 @@ same task selection and preemption algorithms as described in the
 previous section, but does not use time slicing to share processing time
 between tasks of equal priority.
 
-The table below shows the FreeRTOSConfig.h settings that configure the FreeRTOS
+The Table 5 shows the FreeRTOSConfig.h settings that configure the FreeRTOS
 scheduler to use prioritized preemptive scheduling without time slicing.
 
 As was demonstrated in Figure 4.19, if time slicing is used, and there is
@@ -2419,7 +2425,7 @@ Referring to Figure 4.21, which assumes `configIDLE_SHOULD_YIELD` is set to 0:
 ### 4.12.5 Cooperative Scheduling
 
 This book focuses on preemptive scheduling, but FreeRTOS can also use
-cooperative scheduling. The table below shows the FreeRTOSConfig.h settings
+cooperative scheduling. The Table 5 shows the FreeRTOSConfig.h settings
 that configure the FreeRTOS scheduler to use cooperative scheduling.
 
 When using the cooperative scheduler (and therefore assuming

--- a/ch09.md
+++ b/ch09.md
@@ -365,12 +365,12 @@ A task will not enter the Blocked state if its unblock condition is met
 at the time `xEventGroupWaitBits()` is called.
 
 Examples of conditions that will result in a task either entering the
-Blocked state, or exiting the Blocked state, are provided in Table 5.
-Table 5 only shows the least significant four binary bits of the event
+Blocked state, or exiting the Blocked state, are provided in Table 6.
+Table 6 only shows the least significant four binary bits of the event
 group and uxBitsToWaitFor values—the other bits of those two values are
 assumed to be zero.
 
-<a name="tbl5" title="Table 5 The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters"></a>
+<a name="tbl6" title="Table 6 The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters"></a>
 
 * * *
 | Existing Event Group Value | uxBitsToWaitFor value | xWaitForAllBits value | Resultant Behavior |
@@ -380,7 +380,7 @@ assumed to be zero.
 | 0100 | 0110 | pdFALSE | The calling task will not enter the Blocked state because xWaitForAllBits is pdFALSE, and one of the two bits specified by uxBitsToWaitFor is already set in the event group. |
 | 0100 | 0110 | pdTRUE | The calling task will enter the Blocked state because xWaitForAllBits is pdTRUE, and only one of the two bits specified by uxBitsToWaitFor is already set in the event group. The task will leave the Blocked state when both bit 1 and bit 2 are set in the event group. |
 
-***Table 5*** *The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters*
+***Table 6*** *The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters*
 * * *
 
 The calling task specifies bits to test using the `uxBitsToWaitFor`
@@ -414,7 +414,7 @@ operation (uninterruptable by other tasks or interrupts).
 
   For example, if the calling task wants to wait for event bit 0 and/or
   event bit 2 to become set in the event group, then set `uxBitsToWaitFor`
-  to 0x05 (binary 0101). Refer to Table 5 for further examples.
+  to 0x05 (binary 0101). Refer to Table 6 for further examples.
 
 - `xClearOnExit`
 
@@ -446,7 +446,7 @@ operation (uninterruptable by other tasks or interrupts).
   `uxBitsToWaitFor` are set (or the timeout specified by the `xTicksToWait`
   parameter expires).
 
-  Refer to Table 5 for examples.
+  Refer to Table 6 for examples.
 
 - `xTicksToWait`
 

--- a/toc.md
+++ b/toc.md
@@ -603,4 +603,5 @@
 + [Table 2 TickType\_t data type and the configTICK\_TYPE\_WIDTH\_IN\_BITS configuration](ch02.md#tbl2)
 + [Table 3 Macro prefixes](ch02.md#tbl3)
 + [Table 4 Common macro definitions](ch02.md#tbl4)
-+ [Table 5 The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters](ch09.md#tbl5)
++ [Table 5 The FreeRTOSConfig.h settings that configure the kernel to use various scheduling algorithms](ch04.md#tbl5)
++ [Table 6 The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters](ch09.md#tbl6)

--- a/toc.md
+++ b/toc.md
@@ -603,5 +603,5 @@
 + [Table 2 TickType\_t data type and the configTICK\_TYPE\_WIDTH\_IN\_BITS configuration](ch02.md#tbl2)
 + [Table 3 Macro prefixes](ch02.md#tbl3)
 + [Table 4 Common macro definitions](ch02.md#tbl4)
-+ [Table 5 The FreeRTOSConfig.h settings that configure the kernel to use various scheduling algorithms](ch04.md#tbl5)
++ [Table 5 The FreeRTOSConfig.h settings to configure the kernel scheduling algorithms](ch04.md#tbl5)
 + [Table 6 The Effect of the uxBitsToWaitFor and xWaitForAllBits Parameters](ch09.md#tbl6)


### PR DESCRIPTION
*Issue #, if available:*
https://forums.freertos.org/t/suggestions-for-mastering-the-freertos-real-time-kernel-1-0/19490/3

*Description of changes:*
This PR adds changes as requested in the forum for Chapter4.

1. Adds a table for FreeRTOS scheduling algorithm configuration
2. Fixes the output for **Example 4.6**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
