### PR TITLE
Listing 3.13: Made comments correctly refer to the Timer task instead of Idle task

### DIFF
--- a/ch03.md
+++ b/ch03.md
@@ -855,20 +855,20 @@ void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
                                      StackType_t **ppxTimerTaskStackBuffer,
                                      uint32_t *pulTimerTaskStackSize )
 {
-  /* If the buffers to be provided to the Idle task are declared inside this
+  /* If the buffers to be provided to the Timer task are declared inside this
   function then they must be declared static - otherwise they will be allocated on
   the stack and hence would not exists after this function exits. */
   static StaticTask_t xTimerTaskTCB;
   static StackType_t uxTimerTaskStack[ configMINIMAL_STACK_SIZE ];
 
-  /* Pass out a pointer to the StaticTask_t structure in which the Idle task's
+  /* Pass out a pointer to the StaticTask_t structure in which the Timer task's
   state will be stored. */
   *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
 
-  /* Pass out the array that will be used as the Idle task's stack. */
+  /* Pass out the array that will be used as the Timer task's stack. */
   *ppxTimerTaskStackBuffer = uxTimerTaskStack;
 
-  /* Pass out the stack size of the array pointed to by *ppxIdleTaskStackBuffer.
+  /* Pass out the stack size of the array pointed to by *ppxTimerTaskStackBuffer.
   Note the stack size is a count of StackType_t */
   *pulTimerTaskStackSize = sizeof(uxTimerTaskStack) / sizeof(*uxTimerTaskStack);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The comments in Listing 3.13 incorrectly referred to the Idle task. This pull requests corrects this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
