### PR TITLE
Add minor comment for vTaskPriorityGet()

### DIFF
--- a/ch04.md
+++ b/ch04.md
@@ -115,7 +115,7 @@ it does so from the instruction it was about to execute before it left the
 <a name="fig4.1" title="Figure 4.1 Top level task states and transitions"></a>
 
 ***
-![](media/figure_4.1_top_level_task_states.png)  
+![](media/figure_4.1_top_level_task_states.png)
 ***Figure 4.1*** *Top level task states and transitions*
 ***
 
@@ -434,7 +434,7 @@ enters the *Not Running* state (the task is switched out).
 <a name="fig4.3" title="Figure 4.3 The actual execution pattern of the two Example 4.1 tasks"></a>
 
 ***
-![](media/figure_4.3_example_4.1_execution_pattern.png)  
+![](media/figure_4.3_example_4.1_execution_pattern.png)
 ***Figure 4.3*** *The actual execution pattern of the two Example 4.1 tasks*
 ***
 
@@ -561,7 +561,7 @@ int main( void )
      */
 
     /* Create one of the two tasks. */
-    xTaskCreate( vTaskFunction,             /* Pointer to the function that 
+    xTaskCreate( vTaskFunction,             /* Pointer to the function that
                                                implements the task. */
                  "Task 1",                  /* Text name for the task. This is to
                                                facilitate debugging only. */
@@ -659,7 +659,7 @@ if it is left undefined.
 ## 4.6 Time Measurement and the Tick Interrupt
 
 [Section 4.12, Scheduling Algorithms](#412-scheduling-algorithms), describes an
-optional feature called 'time slicing'. Time slicing was used in the examples 
+optional feature called 'time slicing'. Time slicing was used in the examples
 presented so far, and is the behavior observed in the output they produced.
 In the examples, both tasks were created at the same priority, and both
 tasks were always able to run. Therefore, each task executed for a 'time
@@ -696,7 +696,7 @@ although a value of 100 is typical.
 <a name="fig4.4" title="Figure 4.4 The execution sequence expanded to show the tick interrupt executing"></a>
 
 ***
-![](media/figure_4.4_expanded_execution_sequence_with_tick_interrupt.png)  
+![](media/figure_4.4_expanded_execution_sequence_with_tick_interrupt.png)
 ***Figure 4.4*** *The execution sequence expanded to show the tick interrupt executing*
 ***
 
@@ -722,7 +722,7 @@ equivalent time specified in ticks.
 TickType_t xTimeInTicks = pdMS_TO_TICKS( 200 );
 ```
 
-***Listing 4.10*** *Using the pdMS\_TO\_TICKS() macro to convert 200 milliseconds 
+***Listing 4.10*** *Using the pdMS\_TO\_TICKS() macro to convert 200 milliseconds
 into an equivalent time in tick periods*
 
 Using `pdMS_TO_TICKS()` to specify times in milliseconds, rather than
@@ -836,7 +836,7 @@ either cycling around a null loop or printing to the terminal.
 <a name="fig4.6" title="Figure 4.6 The execution pattern when one task has a higher priority than the..."></a>
 
 ***
-![](media/figure_4.6_execution_pattern_higher_priority_task.png)  
+![](media/figure_4.6_execution_pattern_higher_priority_task.png)
 ***Figure 4.6*** *The execution pattern when one task has a higher priority than the
 other from Example 4.3*
 
@@ -914,7 +914,7 @@ Figure 4.7 expands on the simplified state diagram to include all of the
 <a name="fig4.7" title="Figure 4.7 Full task state machine"></a>
 
 ***
-![](media/figure_4.7_full_task_state_machine.png)  
+![](media/figure_4.7_full_task_state_machine.png)
 ***Figure 4.7*** *Full task state machine*
 ***
 
@@ -1057,7 +1057,7 @@ describes the Idle task in more detail.
 <a name="fig4.9" title="Figure 4.9 The execution sequence when the tasks use vTaskDelay() in place of the null loop"></a>
 
 ***
-![](media/figure_4.9_vTaskDelay_execution_sequence.png)  
+![](media/figure_4.9_vTaskDelay_execution_sequence.png)
 ***Figure 4.9*** *The execution sequence when the tasks use vTaskDelay() in place of
 the null loop*
 ***
@@ -1095,7 +1095,7 @@ before being returned to the *Ready* state.
 <a name="fig4.10" title="Figure 4.10 Bold lines indicate the state transitions performed by the tasks..."></a>
 
 ***
-![](media/figure_4.10_example_4.4_state_machine.png)  
+![](media/figure_4.10_example_4.4_state_machine.png)
 ***Figure 4.10*** *Bold lines indicate the state transitions performed by the tasks
 in Example 4.4*
 ***
@@ -1179,17 +1179,17 @@ void vTaskFunction( void * pvParameters )
     char * pcTaskName;
     TickType_t xLastWakeTime;
 
-    /* 
+    /*
      * The string to print out is passed in via the parameter. Cast this to a
-     * character pointer. 
+     * character pointer.
      */
     pcTaskName = ( char * ) pvParameters;
 
-    /* 
+    /*
      * The xLastWakeTime variable needs to be initialized with the current tick
      * count. Note that this is the only time the variable is written to
      * explicitly. After this xLastWakeTime is automatically updated within
-     * vTaskDelayUntil(). 
+     * vTaskDelayUntil().
      */
     xLastWakeTime = xTaskGetTickCount();
 
@@ -1199,12 +1199,12 @@ void vTaskFunction( void * pvParameters )
         /* Print out the name of this task. */
         vPrintLine( pcTaskName );
 
-        /* 
+        /*
          * This task should execute every 250 milliseconds exactly. As per
          * the vTaskDelay() function, time is measured in ticks, and the
          * pdMS_TO_TICKS() macro is used to convert milliseconds into ticks.
          * xLastWakeTime is automatically updated within vTaskDelayUntil(), so
-         * is not explicitly updated by the task. 
+         * is not explicitly updated by the task.
          */
         vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS( 250 ) );
     }
@@ -1252,18 +1252,18 @@ void vContinuousProcessingTask( void * pvParameters )
 {
     char * pcTaskName;
 
-    /* 
+    /*
      * The string to print out is passed in via the parameter. Cast this to a
-     * character pointer. 
+     * character pointer.
      */
     pcTaskName = ( char * ) pvParameters;
 
     /* As per most tasks, this task is implemented in an infinite loop. */
     for( ;; )
     {
-        /* 
+        /*
          * Print out the name of this task. This task just does this repeatedly
-         * without ever blocking or delaying. 
+         * without ever blocking or delaying.
          */
         vPrintLine( pcTaskName );
     }
@@ -1297,9 +1297,9 @@ void vPeriodicTask( void * pvParameters )
         /* Print out the name of this task. */
         vPrintLine( "Periodic task is running" );
 
-        /* 
+        /*
          * The task should execute every 3 milliseconds exactly – see the
-         * declaration of xDelay3ms in this function. 
+         * declaration of xDelay3ms in this function.
          */
         vTaskDelayUntil( &xLastWakeTime, xDelay3ms );
     }
@@ -1350,7 +1350,7 @@ Continuous task 2 running
 <a name="fig4.12" title="Figure 4.12 The execution pattern of Example 4.6"></a>
 
 ***
-![](media/figure_4.11_example_4.6_execution_pattern.png)  
+![](media/figure_4.11_example_4.6_execution_pattern.png)
 ***Figure 4.12*** *The execution pattern of Example 4.6*
 ***
 
@@ -1570,7 +1570,7 @@ FreeRTOSConfig.h.
 <a name="list4.21" title="Listing 4.21 The vTaskPrioritySet() API function prototype"></a>
 
 ```c
-void vTaskPrioritySet( TaskHandle_t xTask, 
+void vTaskPrioritySet( TaskHandle_t xTask,
                        UBaseType_t uxNewPriority );
 ```
 
@@ -1617,7 +1617,8 @@ UBaseType_t uxTaskPriorityGet( TaskHandle_t xTask );
 
   The handle of the task whose priority is being queried (the
   subject task). See the `pxCreatedTask` parameter of the `xTaskCreate()` API
-  function for information on how to obtain handles to tasks.
+  function, or the return value of the `xTaskCreateStatic()` API function,
+  for information on how to obtain handles to tasks.
 
   A task can query its own priority by passing NULL in place of a valid
   task handle.
@@ -1671,7 +1672,7 @@ void vTask1( void * pvParameters )
 {
     UBaseType_t uxPriority;
 
-    /* 
+    /*
      * This task will always run before Task 2 as it is created with the higher
      * priority. Neither Task 1 nor Task 2 ever block so both will always be in
      * either the Running or the Ready state.
@@ -1811,7 +1812,7 @@ execute, and the resultant output is shown in Figure 4.15.
 <a name="fig4.14" title="Figure 4.14 The sequence of task execution when running Example 4.8"></a>
 
 ***
-![](media/figure_4.14_example_4.8_execution_sequence.png)  
+![](media/figure_4.14_example_4.8_execution_sequence.png)
 ***Figure 4.14*** *The sequence of task execution when running Example 4.8*
 ***
 
@@ -2023,7 +2024,7 @@ Task2 is running and about to delete itself
 <a name="fig4.17" title="Figure 4.17 The execution sequence for Example 4.9"></a>
 
 ***
-![](media/figure_4.17_example_4.9_execution_sequence.png)  
+![](media/figure_4.17_example_4.9_execution_sequence.png)
 ***Figure 4.17*** *The execution sequence for Example 4.9*
 ***
 
@@ -2083,11 +2084,11 @@ the C Runtime Thread Local Storage block.
 ### 4.11.3 Application Thread Local Storage
 
 In addition to C Runtime Thread Local Storage, application developers may also
-define a set of application specific pointers to be included in the task control 
+define a set of application specific pointers to be included in the task control
 block. This feature is enabled by setting ```configNUM_THREAD_LOCAL_STORAGE_POINTERS```
 to a non-zero number in the project's FreeRTOSConfig.h file.
 The ```vTaskSetThreadLocalStoragePointer``` and ```pvTaskGetThreadLocalStoragePointer```
-functions defined in Listing 4.30 may be used respectively to set and get the 
+functions defined in Listing 4.30 may be used respectively to set and get the
 value of each thread local storage pointer at runtime.
 
 
@@ -2218,7 +2219,7 @@ priority.
 <a name="fig4.18" title="Figure 4.18 Execution pattern highlighting task prioritization and preemption..."></a>
 
 ***
-![](media/figure_4.18_preemption_execution_pattern.png)  
+![](media/figure_4.18_preemption_execution_pattern.png)
 ***Figure 4.18*** *Execution pattern highlighting task prioritization and preemption
 in a hypothetical application in which each task has been assigned a unique
 priority*
@@ -2275,7 +2276,7 @@ Referring to Figure 4.18:
 <a name="fig4.19" title="Figure 4.19 Execution pattern highlighting task prioritization and time slicing..."></a>
 
 ***
-![](media/figure_4.19_time_slicing_execution_pattern.png)  
+![](media/figure_4.19_time_slicing_execution_pattern.png)
 ***Figure 4.19*** *Execution pattern highlighting task prioritization and time slicing
 in a hypothetical application in which two tasks run at the same priority*
 ***
@@ -2334,7 +2335,7 @@ Figure 4.20 is what would be observed in the same scenario when
 <a name="fig4.20" title="Figure 4.20 The execution pattern for the same scenario as shown in Figure 4.19..."></a>
 
 ***
-![](media/figure_4.20_time_slicing_with_yield_execution_pattern.png)  
+![](media/figure_4.20_time_slicing_with_yield_execution_pattern.png)
 ***Figure 4.20*** *The execution pattern for the same scenario as shown in Figure 4.19,
 but this time with `configIDLE_SHOULD_YIELD` set to 1*
 ***
@@ -2378,7 +2379,7 @@ experienced users.
 <a name="fig4.21" title="Figure 4.21 Execution pattern that demonstrates how tasks of equal priority can..."></a>
 
 ***
-![](media/figure_4.21_equal_priority_without_time_slicing_execution_pattern.png)  
+![](media/figure_4.21_equal_priority_without_time_slicing_execution_pattern.png)
 ***Figure 4.21*** *Execution pattern that demonstrates how tasks of equal priority can
 receive hugely different amounts of processing time when time slicing is not used*
 ***
@@ -2443,7 +2444,7 @@ state.
 <a name="fig4.22" title="Figure 4.22 Execution pattern demonstrating the behavior of the cooperative scheduler"></a>
 
 ***
-![](media/figure_4.22_cooperative_scheduler_execution_pattern.png)  
+![](media/figure_4.22_cooperative_scheduler_execution_pattern.png)
 ***Figure 4.22*** *Execution pattern demonstrating the behavior of the cooperative scheduler*
 ***
 
@@ -2528,7 +2529,7 @@ queues and semaphores, are always safe to share between tasks.
 
 - In the above UART example, you can ensure Task 1 does not leave the
   *Running* state until after writing its entire string to the UART
-  and, in doing so, remove the possibility of the string being corrupted by the 
+  and, in doing so, remove the possibility of the string being corrupted by the
   activities of another task.
 
 As demonstrated in Figure 4.22, using the cooperative scheduler makes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In ch04, listing 4.22, there was minor comment
missing about getting a task handle from the
xTaskCreateStatic() function.
As in vTaskPrioritySet() prototype description
there is such comment, it could be misleading
that there is any difference for vTaskPriorityGet().
So it is better if the comment is added also in
its prototype description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
