### PR TITLE
Improve SW timer changing period example

### DIFF
--- a/ch06.md
+++ b/ch06.md
@@ -1133,7 +1133,7 @@ BaseType_t xTimerReset( TimerHandle_t xTimer, TickType_t xTicksToWait );
 
 - `xTicksToWait`
 
-  `xTimerChangePeriod()` uses the timer command queue to send the
+  `xTimerReset()` uses the timer command queue to send the
   'reset' command to the daemon task. `xTicksToWait` specifies the maximum
   amount of time the calling task should remain in the Blocked state to
   wait for space to become available on the timer command queue, if

--- a/ch06.md
+++ b/ch06.md
@@ -113,7 +113,7 @@ a tick interrupt occurs.
 <a name="fig6.1" title="Figure 6.1 The difference in behavior between one-shot and auto-reload software timers"></a>
 
 * * *
-![](media/image38.png)   
+![](media/image38.png)
 ***Figure 6.1*** *The difference in behavior between one-shot and auto-reload software timers*
 * * *
 
@@ -160,10 +160,10 @@ executes its callback function then enters the Dormant state.
 <a name="fig6.3" title="Figure 6.3 One-shot software timer states and transitions"></a>
 
 * * *
-![](media/image39.png)   
+![](media/image39.png)
 ***Figure 6.2*** *Auto-reload software timer states and transitions*
 
-![](media/image40.png)   
+![](media/image40.png)
 ***Figure 6.3*** *One-shot software timer states and transitions*
 * * *
 
@@ -247,7 +247,7 @@ configuration constant in FreeRTOSConfig.h.
 <a name="fig6.4" title="Figure 6.4 The timer command queue being used by a software timer API function to communicate with the RTOS daemon task"></a>
 
 * * *
-![](media/image41.png)   
+![](media/image41.png)
 ***Figure 6.4*** *The timer command queue being used by a software timer API function to communicate with the RTOS daemon task*
 * * *
 
@@ -268,7 +268,7 @@ function.
 <a name="fig6.5" title="Figure 6.5 The execution pattern when the priority of a task calling xTimerStart() is above the priority of the daemon task"></a>
 
 * * *
-![](media/image42.png)   
+![](media/image42.png)
 ***Figure 6.5*** *The execution pattern when the priority of a task calling xTimerStart() is above the priority of the daemon task*
 * * *
 
@@ -339,7 +339,7 @@ that calls `xTimerStart()`.
 <a name="fig6.6" title="Figure 6.6 The execution pattern when the priority of a task calling xTimerStart() is below the priority of the daemon task"></a>
 
 * * *
-![](media/image43.png)   
+![](media/image43.png)
 ***Figure 6.6*** *The execution pattern when the priority of a task calling xTimerStart() is below the priority of the daemon task*
 * * *
 
@@ -591,7 +591,7 @@ timer—as shown in Listing 6.5.
 <a name="list6.5" title="Listing 6.5 Creating and starting the timers used in Example 6.1"></a>
 
 ```c
-/* The periods assigned to the one-shot and auto-reload timers are 3.333 
+/* The periods assigned to the one-shot and auto-reload timers are 3.333
    second and half a second respectively. */
 #define mainONE_SHOT_TIMER_PERIOD pdMS_TO_TICKS( 3333 )
 #define mainAUTO_RELOAD_TIMER_PERIOD pdMS_TO_TICKS( 500 )
@@ -601,13 +601,13 @@ int main( void )
     TimerHandle_t xAutoReloadTimer, xOneShotTimer;
     BaseType_t xTimer1Started, xTimer2Started;
 
-    /* Create the one shot timer, storing the handle to the created timer in 
+    /* Create the one shot timer, storing the handle to the created timer in
        xOneShotTimer. */
     xOneShotTimer = xTimerCreate(
         /* Text name for the software timer - not used by FreeRTOS. */
-                                  "OneShot", 
+                                  "OneShot",
         /* The software timer's period in ticks. */
-                                   mainONE_SHOT_TIMER_PERIOD, 
+                                   mainONE_SHOT_TIMER_PERIOD,
         /* Setting uxAutoRealod to pdFALSE creates a one-shot software timer. */
                                    pdFALSE,
         /* This example does not use the timer id. */
@@ -615,7 +615,7 @@ int main( void )
         /* Callback function to be used by the software timer being created. */
                                    prvOneShotTimerCallback );
 
-    /* Create the auto-reload timer, storing the handle to the created timer 
+    /* Create the auto-reload timer, storing the handle to the created timer
        in xAutoReloadTimer. */
     xAutoReloadTimer = xTimerCreate(
         /* Text name for the software timer - not used by FreeRTOS. */
@@ -633,16 +633,16 @@ int main( void )
     if( ( xOneShotTimer != NULL ) && ( xAutoReloadTimer != NULL ) )
     {
         /* Start the software timers, using a block time of 0 (no block time).
-           The scheduler has not been started yet so any block time specified 
+           The scheduler has not been started yet so any block time specified
            here would be ignored anyway. */
         xTimer1Started = xTimerStart( xOneShotTimer, 0 );
         xTimer2Started = xTimerStart( xAutoReloadTimer, 0 );
 
         /* The implementation of xTimerStart() uses the timer command queue,
-           and xTimerStart() will fail if the timer command queue gets full. 
-           The timer service task does not get created until the scheduler is 
+           and xTimerStart() will fail if the timer command queue gets full.
+           The timer service task does not get created until the scheduler is
            started, so all commands sent to the command queue will stay in the
-           queue until after the scheduler has been started. Check both calls 
+           queue until after the scheduler has been started. Check both calls
            to xTimerStart() passed. */
         if( ( xTimer1Started == pdPASS ) && ( xTimer2Started == pdPASS ) )
         {
@@ -691,7 +691,7 @@ static void prvAutoReloadTimerCallback( TimerHandle_t xTimer )
 {
     TickType_t xTimeNow;
 
-    /* Obtain the current tick count. */ 
+    /* Obtain the current tick count. */
     xTimeNow = xTaskGetTickCount();
 
     /* Output a string to show the time at which the callback was executed. */
@@ -713,7 +713,7 @@ once, when the tick count is 3333 (`mainONE_SHOT_TIMER_PERIOD` is set to
 <a name="fig6.7" title="Figure 6.7 The output produced when Example 6.1 is executed"></a>
 
 * * *
-![](media/image44.jpg)   
+![](media/image44.jpg)
 ***Figure 6.7*** *The output produced when Example 6.1 is executed*
 * * *
 
@@ -807,21 +807,21 @@ timers are created. This difference is shown in Listing 6.10, where
 <a name="list6.10" title="Listing 6.10 Creating the timers used in Example 6.2"></a>
 
 ```c
-/* Create the one shot timer software timer, storing the handle in 
+/* Create the one shot timer software timer, storing the handle in
    xOneShotTimer. */
 xOneShotTimer = xTimerCreate( "OneShot",
                               mainONE_SHOT_TIMER_PERIOD,
-                              pdFALSE, 
+                              pdFALSE,
                               /* The timer's ID is initialized to NULL. */
                               NULL,
                               /* prvTimerCallback() is used by both timers. */
                               prvTimerCallback );
 
-/* Create the auto-reload software timer, storing the handle in 
+/* Create the auto-reload software timer, storing the handle in
    xAutoReloadTimer */
 xAutoReloadTimer = xTimerCreate( "AutoReload",
                                  mainAUTO_RELOAD_TIMER_PERIOD,
-                                 pdTRUE, 
+                                 pdTRUE,
                                  /* The timer's ID is initialized to NULL. */
                                  NULL,
                                  /* prvTimerCallback() is used by both timers. */
@@ -850,8 +850,8 @@ static void prvTimerCallback( TimerHandle_t xTimer )
     TickType_t xTimeNow;
     uint32_t ulExecutionCount;
 
-    /* A count of the number of times this software timer has expired is 
-       stored in the timer's ID. Obtain the ID, increment it, then save it as 
+    /* A count of the number of times this software timer has expired is
+       stored in the timer's ID. Obtain the ID, increment it, then save it as
        the new ID value. The ID is a void pointer, so is cast to a uint32_t. */
     ulExecutionCount = ( uint32_t ) pvTimerGetTimerID( xTimer );
     ulExecutionCount++;
@@ -860,10 +860,10 @@ static void prvTimerCallback( TimerHandle_t xTimer )
     /* Obtain the current tick count. */
     xTimeNow = xTaskGetTickCount();
 
-    /* The handle of the one-shot timer was stored in xOneShotTimer when the 
-       timer was created. Compare the handle passed into this function with 
-       xOneShotTimer to determine if it was the one-shot or auto-reload timer 
-       that expired, then output a string to show the time at which the 
+    /* The handle of the one-shot timer was stored in xOneShotTimer when the
+       timer was created. Compare the handle passed into this function with
+       xOneShotTimer to determine if it was the one-shot or auto-reload timer
+       that expired, then output a string to show the time at which the
        callback was executed. */
     if( xTimer == xOneShotTimer )
     {
@@ -871,16 +871,16 @@ static void prvTimerCallback( TimerHandle_t xTimer )
     }
     else
     {
-        /* xTimer did not equal xOneShotTimer, so it must have been the 
+        /* xTimer did not equal xOneShotTimer, so it must have been the
            auto-reload timer that expired. */
         vPrintStringAndNumber( "Auto-reload timer callback executing", xTimeNow);
 
         if( ulExecutionCount == 5 )
         {
             /* Stop the auto-reload timer after it has executed 5 times. This
-               callback function executes in the context of the RTOS daemon 
+               callback function executes in the context of the RTOS daemon
                task so must not call any functions that might place the daemon
-               task into the Blocked state. Therefore a block time of 0 is 
+               task into the Blocked state. Therefore a block time of 0 is
                used. */
             xTimerStop( xTimer, 0 );
         }
@@ -897,7 +897,7 @@ that the auto-reload timer only executes five times.
 <a name="fig6.8" title="Figure 6.8 The output produced when Example 6.2 is executed"></a>
 
 * * *
-![](media/image45.jpg)   
+![](media/image45.jpg)
 ***Figure 6.8*** *The output produced when Example 6.2 is executed*
 * * *
 
@@ -1020,9 +1020,9 @@ referred to as the 'check timer'.
 <a name="list6.13" title="Listing 6.13 Using xTimerChangePeriod()"></a>
 
 ```c
-/* The check timer is created with a period of 3000 milliseconds, resulting 
-   in the LED toggling every 3 seconds. If the self-checking functionality 
-   detects an unexpected state, then the check timer's period is changed to 
+/* The check timer is created with a period of 3000 milliseconds, resulting
+   in the LED toggling every 3 seconds. If the self-checking functionality
+   detects an unexpected state, then the check timer's period is changed to
    just 200 milliseconds, resulting in a much faster toggle rate. */
 const TickType_t xHealthyTimerPeriod = pdMS_TO_TICKS( 3000 );
 const TickType_t xErrorTimerPeriod = pdMS_TO_TICKS( 200 );
@@ -1034,33 +1034,33 @@ static void prvCheckTimerCallbackFunction( TimerHandle_t xTimer )
 
     if( xErrorDetected == pdFALSE )
     {
-        /* No errors have yet been detected. Run the self-checking function 
+        /* No errors have yet been detected. Run the self-checking function
            again. The function asks each task created by the example to report
-           its own status, and also checks that all the tasks are actually 
+           its own status, and also checks that all the tasks are actually
            still running (and so able to report their status correctly). */
         if( CheckTasksAreRunningWithoutError() == pdFAIL )
         {
-            /* One or more tasks reported an unexpected status. An error might 
-               have occurred. Reduce the check timer's period to increase the 
-               rate at which this callback function executes, and in so doing 
-               also increase the rate at which the LED is toggled. This 
+            /* One or more tasks reported an unexpected status. An error might
+               have occurred. Reduce the check timer's period to increase the
+               rate at which this callback function executes, and in so doing
+               also increase the rate at which the LED is toggled. This
                callback function is executing in the context of the RTOS daemon
-               task, so a block time of 0 is used to ensure the Daemon task 
+               task, so a block time of 0 is used to ensure the Daemon task
                never enters the Blocked state. */
-            xTimerChangePeriod( 
+            xTimerChangePeriod(
                   xTimer,            /* The timer being updated */
                   xErrorTimerPeriod, /* The new period for the timer */
                   0 );               /* Do not block when sending this command */
-        }
 
-        /* Latch that an error has already been detected. */
-        xErrorDetected = pdTRUE;
+            /* Latch that an error has already been detected. */
+            xErrorDetected = pdTRUE;
+        }
     }
 
-    /* Toggle the LED. The rate at which the LED toggles will depend on how 
+    /* Toggle the LED. The rate at which the LED toggles will depend on how
        often this function is called, which is determined by the period of the
-       check timer. The timer's period will have been reduced from 3000ms to 
-       just 200ms if CheckTasksAreRunningWithoutError() has ever returned 
+       check timer. The timer's period will have been reduced from 3000ms to
+       just 200ms if CheckTasksAreRunningWithoutError() has ever returned
        pdFAIL. */
     ToggleLED();
 }
@@ -1080,7 +1080,7 @@ function.
 <a name="fig6.9" title="Figure 6.9 Starting and resetting a software timer that has a period of 6 ticks"></a>
 
 * * *
-![](media/image46.png)   
+![](media/image46.png)
 ***Figure 6.9*** *Starting and resetting a software timer that has a period of 6 ticks*
 * * *
 
@@ -1256,9 +1256,9 @@ static void vKeyHitTask( void *pvParameters )
 
     vPrintString( "Press a key to turn the backlight on.\r\n" );
 
-    /* Ideally an application would be event driven, and use an interrupt to 
-       process key presses. It is not practical to use keyboard interrupts 
-       when using the FreeRTOS Windows port, so this task is used to poll for 
+    /* Ideally an application would be event driven, and use an interrupt to
+       process key presses. It is not practical to use keyboard interrupts
+       when using the FreeRTOS Windows port, so this task is used to poll for
        a key press. */
     for( ;; )
     {
@@ -1271,32 +1271,32 @@ static void vKeyHitTask( void *pvParameters )
             if( xSimulatedBacklightOn == pdFALSE )
             {
 
-                /* The backlight was off, so turn it on and print the time at 
+                /* The backlight was off, so turn it on and print the time at
                    which it was turned on. */
                 xSimulatedBacklightOn = pdTRUE;
                 vPrintStringAndNumber(
-                    "Key pressed, turning backlight ON at time\t\t", 
+                    "Key pressed, turning backlight ON at time\t\t",
                     xTimeNow );
             }
             else
             {
                 /* The backlight was already on, so print a message to say the
-                   timer is about to be reset and the time at which it was 
+                   timer is about to be reset and the time at which it was
                    reset. */
                 vPrintStringAndNumber(
-                    "Key pressed, resetting software timer at time\t\t", 
+                    "Key pressed, resetting software timer at time\t\t",
                     xTimeNow );
             }
 
-            /* Reset the software timer. If the backlight was previously off, 
-               then this call will start the timer. If the backlight was 
-               previously on, then this call will restart the timer. A real 
-               application may read key presses in an interrupt. If this 
-               function was an interrupt service routine then 
+            /* Reset the software timer. If the backlight was previously off,
+               then this call will start the timer. If the backlight was
+               previously on, then this call will restart the timer. A real
+               application may read key presses in an interrupt. If this
+               function was an interrupt service routine then
                xTimerResetFromISR() must be used instead of xTimerReset(). */
             xTimerReset( xBacklightTimer, xShortDelay );
 
-            /* Read and discard the key that was pressed – it is not required 
+            /* Read and discard the key that was pressed – it is not required
                by this simple example. */
             ( void ) _getch();
         }
@@ -1323,7 +1323,7 @@ With reference to Figure 6.10:
 <a name="fig6.10" title="Figure 6.10 The output produced when Example 6.3 is executed"></a>
 
 * * *
-![](media/image47.jpg)   
+![](media/image47.jpg)
 ***Figure 6.10*** *The output produced when Example 6.3 is executed*
 * * *
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the example in Listing 6.13, there is a flag,
which should indicate that an error has been
detected by CheckTasksAreRunningWithoutError().
This flag was always set, even if the result from
the function call is not pdFAIL. For correct
usage of the flag it should be placed inside the
if condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
