### PR TITLE
Fix reference to critical sections and task notifications

### DIFF
--- a/ch07.md
+++ b/ch07.md
@@ -179,18 +179,18 @@ is called:
   writer that a context switch should be performed. Interrupt safe API
   functions (those that end in "FromISR") have a pointer parameter
   called `pxHigherPriorityTaskWoken` that is used for this purpose.
- 
+
   If a context switch should be performed, then the interrupt safe API
   function will set `*pxHigherPriorityTaskWoken` to `pdTRUE`. To be able to
   detect this has happened, the variable pointed to by
   `pxHigherPriorityTaskWoken` must be initialized to `pdFALSE` before it is
   used for the first time.
- 
+
   If the application writer opts not to request a context switch from
   the ISR, then the higher priority task will remain in the Ready state
   until the next time the scheduler runs, which in the worst case will be
   during the next tick interrupt.
- 
+
   FreeRTOS API functions can only set `*pxHighPriorityTaskWoken` to
   `pdTRUE`. If an ISR calls more than one FreeRTOS API function, then the
   same variable can be passed as the `pxHigherPriorityTaskWoken` parameter
@@ -343,7 +343,7 @@ processing is deferred.
 <a name="fig7.1" title="Figure 7.1 Completing interrupt processing in a high priority task"></a>
 
 * * *
-![](media/image48.png)   
+![](media/image48.png)
 ***Figure 7.1*** *Completing interrupt processing in a high priority task*
 * * *
 
@@ -407,7 +407,7 @@ task can be controlled using a semaphore.
 <a name="fig7.2" title="Figure 7.2 Using a binary semaphore to implement deferred interrupt processing"></a>
 
 * * *
-![](media/image49.png)   
+![](media/image49.png)
 ***Figure 7.2*** *Using a binary semaphore to implement deferred interrupt processing*
 * * *
 
@@ -446,7 +446,7 @@ back—such as the scenarios described in Chapter 8, Resource Management.
 <a name="fig7.3" title="Figure 7.3 Using a binary semaphore to synchronize a task with an interrupt"></a>
 
 * * *
-![](media/image50.png)   
+![](media/image50.png)
 ***Figure 7.3*** *Using a binary semaphore to synchronize a task with an interrupt*
 * * *
 
@@ -657,9 +657,9 @@ static void vPeriodicTask( void *pvParameters )
            the interrupt has been generated, so the sequence of execution is
            evident from the output.
 
-           The syntax used to generate a software interrupt is dependent on 
-           the FreeRTOS port being used. The syntax used below can only be 
-           used with the FreeRTOS Windows port, in which such interrupts are 
+           The syntax used to generate a software interrupt is dependent on
+           the FreeRTOS port being used. The syntax used below can only be
+           used with the FreeRTOS Windows port, in which such interrupts are
            only simulated. */
         vPrintString( "Periodic task - About to generate an interrupt.\r\n" );
         vPortGenerateSimulatedInterrupt( mainINTERRUPT_NUMBER );
@@ -694,14 +694,14 @@ static void vHandlerTask( void *pvParameters )
     for( ;; )
     {
         /* Use the semaphore to wait for the event. The semaphore was created
-           before the scheduler was started, so before this task ran for the 
-           first time. The task blocks indefinitely, meaning this function 
-           call will only return once the semaphore has been successfully 
-           obtained - so there is no need to check the value returned by 
+           before the scheduler was started, so before this task ran for the
+           first time. The task blocks indefinitely, meaning this function
+           call will only return once the semaphore has been successfully
+           obtained - so there is no need to check the value returned by
            xSemaphoreTake(). */
         xSemaphoreTake( xBinarySemaphore, portMAX_DELAY );
 
-        /* To get here the event must have occurred. Process the event (in 
+        /* To get here the event must have occurred. Process the event (in
            this Case, just print out a message). */
         vPrintString( "Handler task - Processing event.\r\n" );
     }
@@ -741,7 +741,7 @@ static uint32_t ulExampleInterruptHandler( void )
     BaseType_t xHigherPriorityTaskWoken;
 
     /* The xHigherPriorityTaskWoken parameter must be initialized to
-       pdFALSE as it will get set to pdTRUE inside the interrupt safe 
+       pdFALSE as it will get set to pdTRUE inside the interrupt safe
        API function if a context switch is required. */
     xHigherPriorityTaskWoken = pdFALSE;
 
@@ -752,10 +752,10 @@ static uint32_t ulExampleInterruptHandler( void )
 
     /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().
        If xHigherPriorityTaskWoken was set to pdTRUE inside
-       xSemaphoreGiveFromISR() then calling portYIELD_FROM_ISR() will request 
-       a context switch. If xHigherPriorityTaskWoken is still pdFALSE then 
-       calling portYIELD_FROM_ISR() will have no effect. Unlike most FreeRTOS 
-       ports, the Windows port requires the ISR to return a value - the return 
+       xSemaphoreGiveFromISR() then calling portYIELD_FROM_ISR() will request
+       a context switch. If xHigherPriorityTaskWoken is still pdFALSE then
+       calling portYIELD_FROM_ISR() will have no effect. Unlike most FreeRTOS
+       ports, the Windows port requires the ISR to return a value - the return
        statement is inside the Windows version of portYIELD_FROM_ISR(). */
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
@@ -786,21 +786,21 @@ int main( void )
     if( xBinarySemaphore != NULL )
     {
         /* Create the 'handler' task, which is the task to which interrupt
-           processing is deferred. This is the task that will be synchronized 
+           processing is deferred. This is the task that will be synchronized
            with the interrupt. The handler task is created with a high priority
-           to ensure it runs immediately after the interrupt exits. In this 
+           to ensure it runs immediately after the interrupt exits. In this
            case a priority of 3 is chosen. */
         xTaskCreate( vHandlerTask, "Handler", 1000, NULL, 3, NULL );
 
         /* Create the task that will periodically generate a software
-           interrupt. This is created with a priority below the handler task 
-           to ensure it will get preempted each time the handler task exits 
+           interrupt. This is created with a priority below the handler task
+           to ensure it will get preempted each time the handler task exits
            the Blocked state. */
         xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, 1, NULL );
 
         /* Install the handler for the software interrupt. The syntax necessary
            to do this is dependent on the FreeRTOS port being used. The syntax
-           shown here can only be used with the FreeRTOS windows port, where 
+           shown here can only be used with the FreeRTOS windows port, where
            such interrupts are only simulated. */
         vPortSetInterruptHandler( mainINTERRUPT_NUMBER,
                                   ulExampleInterruptHandler );
@@ -826,10 +826,10 @@ periodic task. Further explanation is provided in Figure 7.5.
 <a name="fig7.5" title="Figure 7.5 The sequence of execution when Example 7.1 is executed"></a>
 
 * * *
-![](media/image51.jpg)   
+![](media/image51.jpg)
 ***Figure 7.4*** *The output produced when Example 7.1 is executed*
 
-![](media/image52.png)   
+![](media/image52.png)
 ***Figure 7.5*** *The sequence of execution when Example 7.1 is executed*
 * * *
 
@@ -871,10 +871,10 @@ interrupt:
 <a name="fig7.7" title="Figure 7.7 The scenario when two interrupts occur before the task has finished processing the first event"></a>
 
 * * *
-![](media/image53.png)   
+![](media/image53.png)
 ***Figure 7.6*** *The scenario when one interrupt occurs before the task has finished processing the first event*
 
-![](media/image54.png)   
+![](media/image54.png)
 ***Figure 7.7*** *The scenario when two interrupts occur before the task has finished processing the first event*
 * * *
 
@@ -934,34 +934,34 @@ static void vUARTReceiveHandlerTask( void *pvParameters )
     /* As per most tasks, this task is implemented within an infinite loop. */
     for( ;; )
     {
-        /* The semaphore is 'given' by the UART's receive (Rx) interrupt. 
-           Wait a maximum of xMaxExpectedBlockTime ticks for the next 
+        /* The semaphore is 'given' by the UART's receive (Rx) interrupt.
+           Wait a maximum of xMaxExpectedBlockTime ticks for the next
            interrupt. */
         if( xSemaphoreTake( xBinarySemaphore, xMaxExpectedBlockTime ) == pdPASS)
         {
             /* The semaphore was obtained. Process ALL pending Rx events before
                calling xSemaphoreTake() again. Each Rx event will have placed a
-               character in the UART's receive FIFO, and UART_RxCount() is 
+               character in the UART's receive FIFO, and UART_RxCount() is
                assumed to return the number of characters in the FIFO. */
             while( UART_RxCount() > 0 )
             {
-                /* UART_ProcessNextRxEvent() is assumed to process one Rx 
-                   character, reducing the number of characters in the FIFO 
+                /* UART_ProcessNextRxEvent() is assumed to process one Rx
+                   character, reducing the number of characters in the FIFO
                    by 1. */
                 UART_ProcessNextRxEvent();
             }
 
-            /* No more Rx events are pending (there are no more characters in 
-               the FIFO), so loop back and call xSemaphoreTake() to wait for 
+            /* No more Rx events are pending (there are no more characters in
+               the FIFO), so loop back and call xSemaphoreTake() to wait for
                the next interrupt. Any interrupts occurring between this point
-               in the code and the call to xSemaphoreTake() will be latched in 
+               in the code and the call to xSemaphoreTake() will be latched in
                the semaphore, so will not be lost. */
         }
         else
         {
-            /* An event was not received within the expected time. Check for, 
-               and if necessary clear, any error conditions in the UART that 
-               might be preventing the UART from generating any more 
+            /* An event was not received within the expected time. Check for,
+               and if necessary clear, any error conditions in the UART that
+               might be preventing the UART from generating any more
                interrupts. */
             UART_ClearErrors();
         }
@@ -1020,7 +1020,7 @@ Counting semaphores are typically used for two things:
 <a name="fig7.8" title="Figure 7.8 Using a counting semaphore to 'count' events"></a>
 
 * * *
-![](media/image55.png)   
+![](media/image55.png)
 ***Figure 7.8*** *Using a counting semaphore to 'count' events*
 * * *
 
@@ -1099,7 +1099,7 @@ a call to `xSemaphoreCreateCounting()` in place of the call to
 
 ```c
 /* Before a semaphore is used it must be explicitly created. In this example a
-   counting semaphore is created. The semaphore is created to have a maximum 
+   counting semaphore is created. The semaphore is created to have a maximum
    count value of 10, and an initial count value of 0. */
 xCountingSemaphore = xSemaphoreCreateCounting( 10, 0 );
 ```
@@ -1119,17 +1119,17 @@ static uint32_t ulExampleInterruptHandler( void )
 {
     BaseType_t xHigherPriorityTaskWoken;
 
-    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE 
-       as it will get set to pdTRUE inside the interrupt safe API function if 
+    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE
+       as it will get set to pdTRUE inside the interrupt safe API function if
        a context switch is required. */
     xHigherPriorityTaskWoken = pdFALSE;
 
     /* 'Give' the semaphore multiple times. The first will unblock the deferred
-       interrupt handling task, the following 'gives' are to demonstrate that 
-       the semaphore latches the events to allow the task to which interrupts 
-       are deferred to process them in turn, without events getting lost. This 
-       simulates multiple interrupts being received by the processor, even 
-       though in this case the events are simulated within a single interrupt 
+       interrupt handling task, the following 'gives' are to demonstrate that
+       the semaphore latches the events to allow the task to which interrupts
+       are deferred to process them in turn, without events getting lost. This
+       simulates multiple interrupts being received by the processor, even
+       though in this case the events are simulated within a single interrupt
        occurrence. */
     xSemaphoreGiveFromISR( xCountingSemaphore, &xHigherPriorityTaskWoken );
     xSemaphoreGiveFromISR( xCountingSemaphore, &xHigherPriorityTaskWoken );
@@ -1137,9 +1137,9 @@ static uint32_t ulExampleInterruptHandler( void )
 
     /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR().
        If xHigherPriorityTaskWoken was set to pdTRUE inside
-       xSemaphoreGiveFromISR() then calling portYIELD_FROM_ISR() will request 
-       a context switch. If xHigherPriorityTaskWoken is still pdFALSE then 
-       calling portYIELD_FROM_ISR() will have no effect. Unlike most FreeRTOS 
+       xSemaphoreGiveFromISR() then calling portYIELD_FROM_ISR() will request
+       a context switch. If xHigherPriorityTaskWoken is still pdFALSE then
+       calling portYIELD_FROM_ISR() will have no effect. Unlike most FreeRTOS
        ports, the Windows port requires the ISR to return a value - the return
        statement is inside the Windows version of portYIELD_FROM_ISR(). */
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
@@ -1159,7 +1159,7 @@ allowing the task to process them in turn.
 <a name="fig7.9" title="Figure 7.9 The output produced when Example 7.2 is executed"></a>
 
 * * *
-![](media/image56.jpg)   
+![](media/image56.jpg)
 ***Figure 7.9*** *The output produced when Example 7.2 is executed*
 * * *
 
@@ -1321,7 +1321,7 @@ using a semaphore, and without creating a task specifically to perform
 the processing necessitated by the interrupt. Instead, the processing is
 performed by the RTOS daemon task.
 
-The interrupt service routine used by Example 7.3 is shown in Listing 7.16. 
+The interrupt service routine used by Example 7.3 is shown in Listing 7.16.
 It calls `xTimerPendFunctionCallFromISR()` to pass a pointer to a
 function called `vDeferredHandlingFunction()` to the daemon task. The
 deferred interrupt processing is performed by the
@@ -1344,15 +1344,15 @@ static uint32_t ulExampleInterruptHandler( void )
     static uint32_t ulParameterValue = 0;
     BaseType_t xHigherPriorityTaskWoken;
 
-    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE 
-       as it will get set to pdTRUE inside the interrupt safe API function if 
+    /* The xHigherPriorityTaskWoken parameter must be initialized to pdFALSE
+       as it will get set to pdTRUE inside the interrupt safe API function if
        a context switch is required. */
     xHigherPriorityTaskWoken = pdFALSE;
 
     /* Send a pointer to the interrupt's deferred handling function to the
-       daemon task. The deferred handling function's pvParameter1 parameter 
-       is not used so just set to NULL. The deferred handling function's 
-       ulParameter2 parameter is used to pass a number that is incremented by 
+       daemon task. The deferred handling function's pvParameter1 parameter
+       is not used so just set to NULL. The deferred handling function's
+       ulParameter2 parameter is used to pass a number that is incremented by
        one each time this interrupt handler executes. */
     xTimerPendFunctionCallFromISR( vDeferredHandlingFunction, /* Function to execute */
                                    NULL, /* Not used */
@@ -1362,11 +1362,11 @@ static uint32_t ulExampleInterruptHandler( void )
 
     /* Pass the xHigherPriorityTaskWoken value into portYIELD_FROM_ISR(). If
        xHigherPriorityTaskWoken was set to pdTRUE inside
-       xTimerPendFunctionCallFromISR() then calling portYIELD_FROM_ISR() will 
-       request a context switch. If xHigherPriorityTaskWoken is still pdFALSE 
-       then calling portYIELD_FROM_ISR() will have no effect. Unlike most 
-       FreeRTOS ports, the Windows port requires the ISR to return a value - 
-       the return statement is inside the Windows version 
+       xTimerPendFunctionCallFromISR() then calling portYIELD_FROM_ISR() will
+       request a context switch. If xHigherPriorityTaskWoken is still pdFALSE
+       then calling portYIELD_FROM_ISR() will have no effect. Unlike most
+       FreeRTOS ports, the Windows port requires the ISR to return a value -
+       the return statement is inside the Windows version
        of portYIELD_FROM_ISR(). */
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
@@ -1388,7 +1388,7 @@ actually used.
 ```c
 static void vDeferredHandlingFunction( void *pvParameter1, uint32_t ulParameter2 )
 {
-    /* Process the event - in this case just print out a message and the value 
+    /* Process the event - in this case just print out a message and the value
        of ulParameter2. pvParameter1 is not used in this example. */
     vPrintStringAndNumber( "Handler function - Processing event ", ulParameter2 );
 }
@@ -1412,19 +1412,19 @@ daemon task leaves the Blocked state.
 ```c
 int main( void )
 {
-    /* The task that generates the software interrupt is created at a priority 
-       below the priority of the daemon task. The priority of the daemon task 
-       is set by the configTIMER_TASK_PRIORITY compile time configuration 
+    /* The task that generates the software interrupt is created at a priority
+       below the priority of the daemon task. The priority of the daemon task
+       is set by the configTIMER_TASK_PRIORITY compile time configuration
        constant in FreeRTOSConfig.h. */
     const UBaseType_t ulPeriodicTaskPriority = configTIMER_TASK_PRIORITY - 1;
 
     /* Create the task that will periodically generate a software interrupt. */
-    xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, ulPeriodicTaskPriority, 
+    xTaskCreate( vPeriodicTask, "Periodic", 1000, NULL, ulPeriodicTaskPriority,
                  NULL );
 
-    /* Install the handler for the software interrupt. The syntax necessary to 
-       do this is dependent on the FreeRTOS port being used. The syntax shown 
-       here can only be used with the FreeRTOS windows port, where such 
+    /* Install the handler for the software interrupt. The syntax necessary to
+       do this is dependent on the FreeRTOS port being used. The syntax shown
+       here can only be used with the FreeRTOS windows port, where such
        interrupts are only simulated. */
     vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
@@ -1452,10 +1452,10 @@ task. Further explanation is provided in Figure 7.11.
 <a name="fig7.11" title="Figure 7.11 The sequence of execution when Example 7.3 is executed"></a>
 
 * * *
-![](media/image57.jpg)   
+![](media/image57.jpg)
 ***Figure 7.10*** *The output produced when Example 7.3 is executed*
 
-![](media/image58.png)   
+![](media/image58.png)
 ***Figure 7.11*** *The sequence of execution when Example 7.3 is executed*
 * * *
 
@@ -1478,7 +1478,7 @@ service routine, and `xQueueReceiveFromISR()` is the version of
 <a name="list7.19" title="Listing 7.19 The xQueueSendToFrontFromISR() API function prototype"></a>
 
 ```c
-BaseType_t xQueueSendToFrontFromISR( QueueHandle_t xQueue, 
+BaseType_t xQueueSendToFrontFromISR( QueueHandle_t xQueue,
                                      const void *pvItemToQueue
                                      BaseType_t *pxHigherPriorityTaskWoken );
 ```
@@ -1618,8 +1618,8 @@ static void vIntegerGenerator( void *pvParameters )
 
         /* Send five numbers to the queue, each value one higher than the
            previous value. The numbers are read from the queue by the interrupt
-           service routine. The interrupt service routine always empties the 
-           queue, so this task is guaranteed to be able to write all five 
+           service routine. The interrupt service routine always empties the
+           queue, so this task is guaranteed to be able to write all five
            values without needing to specify a block time. */
         for( i = 0; i < 5; i++ )
         {
@@ -1628,8 +1628,8 @@ static void vIntegerGenerator( void *pvParameters )
         }
 
         /* Generate the interrupt so the interrupt service routine can read the
-           values from the queue. The syntax used to generate a software 
-           interrupt is dependent on the FreeRTOS port being used. The syntax 
+           values from the queue. The syntax used to generate a software
+           interrupt is dependent on the FreeRTOS port being used. The syntax
            used below can only be used with the FreeRTOS Windows port, in which
            such interrupts are only simulated. */
         vPrintString( "Generator task - About to generate an interrupt.\r\n" );
@@ -1659,7 +1659,7 @@ static uint32_t ulExampleInterruptHandler( void )
     uint32_t ulReceivedNumber;
 
     /* The strings are declared static const to ensure they are not allocated
-       on the interrupt service routine's stack, and so exist even when the 
+       on the interrupt service routine's stack, and so exist even when the
        interrupt service routine is not executing. */
 
     static const char *pcStrings[] =
@@ -1670,11 +1670,11 @@ static uint32_t ulExampleInterruptHandler( void )
         "String 3\r\n"
     };
 
-    /* As always, xHigherPriorityTaskWoken is initialized to pdFALSE to be 
-       able to detect it getting set to pdTRUE inside an interrupt safe API 
-       function.  Note that as an interrupt safe API function can only set 
-       xHigherPriorityTaskWoken to pdTRUE, it is safe to use the same 
-       xHigherPriorityTaskWoken variable in both the call to 
+    /* As always, xHigherPriorityTaskWoken is initialized to pdFALSE to be
+       able to detect it getting set to pdTRUE inside an interrupt safe API
+       function.  Note that as an interrupt safe API function can only set
+       xHigherPriorityTaskWoken to pdTRUE, it is safe to use the same
+       xHigherPriorityTaskWoken variable in both the call to
        xQueueReceiveFromISR() and the call to xQueueSendToBackFromISR(). */
     xHigherPriorityTaskWoken = pdFALSE;
 
@@ -1685,7 +1685,7 @@ static uint32_t ulExampleInterruptHandler( void )
     {
         /* Truncate the received value to the last two bits (values 0 to 3
            inclusive), then use the truncated value as an index into the
-           pcStrings[] array to select a string (char *) to send on the other 
+           pcStrings[] array to select a string (char *) to send on the other
            queue. */
         ulReceivedNumber &= 0x03;
         xQueueSendToBackFromISR( xStringQueue,
@@ -1693,25 +1693,25 @@ static uint32_t ulExampleInterruptHandler( void )
                                  &xHigherPriorityTaskWoken );
     }
 
-    /* If receiving from xIntegerQueue caused a task to leave the Blocked 
-       state, and if the priority of the task that left the Blocked state is 
-       higher than the priority of the task in the Running state, then 
-       xHigherPriorityTaskWoken will have been set to pdTRUE inside 
+    /* If receiving from xIntegerQueue caused a task to leave the Blocked
+       state, and if the priority of the task that left the Blocked state is
+       higher than the priority of the task in the Running state, then
+       xHigherPriorityTaskWoken will have been set to pdTRUE inside
        xQueueReceiveFromISR().
 
        If sending to xStringQueue caused a task to leave the Blocked state, and
-       if the priority of the task that left the Blocked state is higher than 
-       the priority of the task in the Running state, then 
-       xHigherPriorityTaskWoken will have been set to pdTRUE inside 
+       if the priority of the task that left the Blocked state is higher than
+       the priority of the task in the Running state, then
+       xHigherPriorityTaskWoken will have been set to pdTRUE inside
        xQueueSendToBackFromISR().
 
        xHigherPriorityTaskWoken is used as the parameter to portYIELD_FROM_ISR().
        If xHigherPriorityTaskWoken equals pdTRUE then calling portYIELD_FROM_ISR()
-       will request a context switch. If xHigherPriorityTaskWoken is still 
+       will request a context switch. If xHigherPriorityTaskWoken is still
        pdFALSE then calling portYIELD_FROM_ISR() will have no effect.
 
-       The implementation of portYIELD_FROM_ISR() used by the Windows port 
-       includes a return statement, which is why this function does not 
+       The implementation of portYIELD_FROM_ISR() used by the Windows port
+       includes a return statement, which is why this function does not
        explicitly return a value. */
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
@@ -1754,34 +1754,34 @@ int main( void )
 {
     /* Before a queue can be used it must first be created. Create both queues
        used by this example. One queue can hold variables of type uint32_t, the
-       other queue can hold variables of type char*. Both queues can hold a 
-       maximum of 10 items. A real application should check the return values 
+       other queue can hold variables of type char*. Both queues can hold a
+       maximum of 10 items. A real application should check the return values
        to ensure the queues have been successfully created. */
     xIntegerQueue = xQueueCreate( 10, sizeof( uint32_t ) );
     xStringQueue = xQueueCreate( 10, sizeof( char * ) );
 
-    /* Create the task that uses a queue to pass integers to the interrupt 
+    /* Create the task that uses a queue to pass integers to the interrupt
        service routine. The task is created at priority 1. */
     xTaskCreate( vIntegerGenerator, "IntGen", 1000, NULL, 1, NULL );
 
     /* Create the task that prints out the strings sent to it from the
-       interrupt service routine. This task is created at the higher 
+       interrupt service routine. This task is created at the higher
        priority of 2. */
     xTaskCreate( vStringPrinter, "String", 1000, NULL, 2, NULL );
 
     /* Install the handler for the software interrupt. The syntax necessary to
-       do this is dependent on the FreeRTOS port being used. The syntax shown 
-       here can only be used with the FreeRTOS Windows port, where such 
+       do this is dependent on the FreeRTOS port being used. The syntax shown
+       here can only be used with the FreeRTOS Windows port, where such
        interrupts are only simulated. */
     vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulExampleInterruptHandler );
 
     /* Start the scheduler so the created tasks start executing. */
     vTaskStartScheduler();
 
-    /* If all is well then main() will never reach here as the scheduler will 
-       now be running the tasks. If main() does reach here then it is likely 
-       that there was insufficient heap memory available for the idle task 
-       to be created. Chapter 2 provides more information on heap memory 
+    /* If all is well then main() will never reach here as the scheduler will
+       now be running the tasks. If main() does reach here then it is likely
+       that there was insufficient heap memory available for the idle task
+       to be created. Chapter 2 provides more information on heap memory
        management. */
     for( ;; );
 }
@@ -1797,10 +1797,10 @@ five strings in response. More explanation is given in Figure 7.13.
 <a name="fig7.13" title="Figure 7.13 The sequence of execution produced by Example 7.4"></a>
 
 * * *
-![](media/image59.jpg)   
+![](media/image59.jpg)
 ***Figure 7.12*** *The output produced when Example 7.4 is executed*
 
-![](media/image60.png)   
+![](media/image60.png)
 ***Figure 7.13*** *The sequence of execution produced by Example 7.4*
 * * *
 
@@ -1853,12 +1853,12 @@ Each interrupt source has a numeric priority, and a logical priority:
 
   An interrupt's logical priority describes that interrupt's precedence
   over other interrupts.
- 
+
   If two interrupts of differing priority occur at the same time, then
   the processor will execute the ISR for whichever of the two interrupts
   has the higher logical priority before it executes the ISR for
   whichever of the two interrupts has the lower logical priority.
- 
+
   An interrupt can interrupt (nest with) any interrupt that has a lower
   logical priority, but an interrupt cannot interrupt (nest with) any
   interrupt that has an equal or higher logical priority.
@@ -1885,7 +1885,7 @@ Figure 7.14, which shows a scenario where:
 <a name="fig7.14" title="Figure 7.14 Constants affecting interrupt nesting behavior"></a>
 
 * * *
-![](media/image61.png)   
+![](media/image61.png)
 ***Figure 7.14*** *Constants affecting interrupt nesting behavior*
 * * *
 
@@ -1894,7 +1894,7 @@ Referring to Figure 7.14:
 - Interrupts that use priorities 1 to 3, inclusive, are prevented from
   executing while the kernel or the application is inside a critical
   section. ISRs running at these priorities can use interrupt-safe
-  FreeRTOS API functions. Critical sections are described in Chapter 7.
+  FreeRTOS API functions. Critical sections are described in Chapter 8.
 
 - Interrupts that use priority 4, or above, are not affected by
   critical sections, so nothing the scheduler does will prevent these
@@ -1943,7 +1943,7 @@ Cortex-M microcontroller that implements four priority bits.
 <a name="fig7.15" title="Figure 7.15 How a priority of binary 101 is stored by a Cortex-M microcontroller that implements four priority bits"></a>
 
 * * *
-![](media/image62.png)   
+![](media/image62.png)
 ***Figure 7.15*** *How a priority of binary 101 is stored by a Cortex-M microcontroller that implements four priority bits*
 * * *
 

--- a/ch07.md
+++ b/ch07.md
@@ -896,7 +896,7 @@ hardware buffer).
 [^17]: Alternatively, a counting semaphore, or a direct to task
 notification, can be used to count events. Counting semaphores are
 described in the next section. Direct to task notifications are
-described in Chapter 9, Task Notifications. Direct to task
+described in Chapter 10, Task Notifications. Direct to task
 notifications are the preferred method as they are the most
 efficient in both run time and RAM usage.
 
@@ -1000,7 +1000,7 @@ Counting semaphores are typically used for two things:
 
    [^18]: It is more efficient to count events using a direct to task
    notification than it is using a counting semaphore. Direct to task
-   notifications are not covered until Chapter 9.
+   notifications are not covered until Chapter 10.
 
 1. Resource management.
 
@@ -1567,7 +1567,7 @@ that are suitable for production code, include:
 
   [^20]: Direct to task notifications provide the most efficient method of
   unblocking a task from an ISR. Direct to task notifications are
-  covered in Chapter 9, Task Notifications.
+  covered in Chapter 10, Task Notifications.
 
 - Copying each received character into a thread safe RAM buffer[^21].
   Again, a direct to task notification can be used to unblock the task


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Critical sections are described in Chapter 8, not
in Chapter 7.

Direct to task notifications are described in Chapter 10,
not in Chapter 9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
