### PR TITLE
Remove unused variable from EventGroup example

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -76,7 +76,7 @@ in a variable of type `EventBits_t`.
 <a name="fig9.1" title="Figure 9.1 Event flag to bit number mapping in a variable of type EventBits\_t"></a>
 
 * * *
-![](media/image71.png)   
+![](media/image71.png)
 ***Figure 9.1*** *Event flag to bit number mapping in a variable of type EventBits\_t*
 * * *
 
@@ -90,7 +90,7 @@ bits clear, giving the event group a value of 0x92.
 <a name="fig9.2" title="Figure 9.2 An event group in which only bits 1, 4 and 7 are set, and all the other event flags are clear, making the event group's value 0x92"></a>
 
 * * *
-![](media/image72.png)   
+![](media/image72.png)
 ***Figure 9.2*** *An event group in which only bits 1, 4 and 7 are set, and all the other event flags are clear, making the event group's value 0x92*
 * * *
 
@@ -482,8 +482,8 @@ operation (uninterruptable by other tasks or interrupts).
 
 ### 9.3.5 The xEventGroupGetStaticBuffer() API Function
 
-The `xEventGroupGetStaticBuffer()` API function provides a method to retrieve a pointer 
-to a buffer of a statically created event group. It is the same buffer that is supplied 
+The `xEventGroupGetStaticBuffer()` API function provides a method to retrieve a pointer
+to a buffer of a statically created event group. It is the same buffer that is supplied
 at the time of creation of the event group.
 
 *Note: Never call `xEventGroupGetStaticBuffer()` from an interrupt service
@@ -566,7 +566,7 @@ allow the sequence of execution to be seen in the console.
 ```c
 static void vEventBitSettingTask( void *pvParameters )
 {
-    const TickType_t xDelay200ms = pdMS_TO_TICKS( 200UL ), xDontBlock = 0;
+    const TickType_t xDelay200ms = pdMS_TO_TICKS( 200UL );
 
     for( ;; )
     {
@@ -609,17 +609,17 @@ the interrupt is generated every 500 milliseconds.
 ```c
 static uint32_t ulEventBitSettingISR( void )
 {
-    /* The string is not printed within the interrupt service routine, but is 
+    /* The string is not printed within the interrupt service routine, but is
        instead sent to the RTOS daemon task for printing. It is therefore
        declared static to ensure the compiler does not allocate the string on
        the stack of the ISR, as the ISR's stack frame will not exist when the
        string is printed from the daemon task. */
     static const char *pcString = "Bit setting ISR -\t about to set bit 2.\r\n";
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    
-    /* Print out a message to say bit 2 is about to be set. Messages cannot 
-       be printed from an ISR, so defer the actual output to the RTOS daemon 
-       task by pending a function call to run in the context of the RTOS 
+
+    /* Print out a message to say bit 2 is about to be set. Messages cannot
+       be printed from an ISR, so defer the actual output to the RTOS daemon
+       task by pending a function call to run in the context of the RTOS
        daemon task. */
     xTimerPendFunctionCallFromISR( vPrintStringFromDaemonTask,
                                    ( void * ) pcString,
@@ -627,26 +627,26 @@ static uint32_t ulEventBitSettingISR( void )
                                    &xHigherPriorityTaskWoken );
 
     /* Set bit 2 in the event group. */
-    xEventGroupSetBitsFromISR( xEventGroup, 
-                               mainISR_BIT, 
+    xEventGroupSetBitsFromISR( xEventGroup,
+                               mainISR_BIT,
                                &xHigherPriorityTaskWoken );
 
     /* xTimerPendFunctionCallFromISR() and xEventGroupSetBitsFromISR() both
-       write to the timer command queue, and both used the same 
-       xHigherPriorityTaskWoken variable. If writing to the timer command 
-       queue resulted in the RTOS daemon task leaving the Blocked state, and 
-       if the priority of the RTOS daemon task is higher than the priority of 
-       the currently executing task (the task this interrupt interrupted) then 
+       write to the timer command queue, and both used the same
+       xHigherPriorityTaskWoken variable. If writing to the timer command
+       queue resulted in the RTOS daemon task leaving the Blocked state, and
+       if the priority of the RTOS daemon task is higher than the priority of
+       the currently executing task (the task this interrupt interrupted) then
        xHigherPriorityTaskWoken will have been set to pdTRUE.
 
-       xHigherPriorityTaskWoken is used as the parameter to 
-       portYIELD_FROM_ISR(). If xHigherPriorityTaskWoken equals pdTRUE, then 
-       calling portYIELD_FROM_ISR() will request a context switch. If 
-       xHigherPriorityTaskWoken is still pdFALSE, then calling 
+       xHigherPriorityTaskWoken is used as the parameter to
+       portYIELD_FROM_ISR(). If xHigherPriorityTaskWoken equals pdTRUE, then
+       calling portYIELD_FROM_ISR() will request a context switch. If
+       xHigherPriorityTaskWoken is still pdFALSE, then calling
        portYIELD_FROM_ISR() will have no effect.
 
-       The implementation of portYIELD_FROM_ISR() used by the Windows port 
-       includes a return statement, which is why this function does not 
+       The implementation of portYIELD_FROM_ISR() used by the Windows port
+       includes a return statement, which is why this function does not
        explicitly return a value. */
 
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
@@ -677,7 +677,7 @@ static void vEventBitReadingTask( void *pvParameters )
 
     for( ;; )
     {
-        /* Block to wait for event bits to become set within the event 
+        /* Block to wait for event bits to become set within the event
            group. */
         xEventGroupValue = xEventGroupWaitBits( /* The event group to read */
                                                 xEventGroup,
@@ -737,7 +737,7 @@ int main( void )
     /* Create the task that sets event bits in the event group. */
     xTaskCreate( vEventBitSettingTask, "Bit Setter", 1000, NULL, 1, NULL );
 
-    /* Create the task that waits for event bits to get set in the event 
+    /* Create the task that waits for event bits to get set in the event
        group. */
     xTaskCreate( vEventBitReadingTask, "Bit Reader", 1000, NULL, 2, NULL );
 
@@ -746,8 +746,8 @@ int main( void )
     xTaskCreate( vInterruptGenerator, "Int Gen", 1000, NULL, 3, NULL );
 
     /* Install the handler for the software interrupt. The syntax necessary
-       to do this is dependent on the FreeRTOS port being used. The syntax 
-       shown here can only be used with the FreeRTOS Windows port, where such 
+       to do this is dependent on the FreeRTOS port being used. The syntax
+       shown here can only be used with the FreeRTOS Windows port, where such
        interrupts are only simulated. */
     vPortSetInterruptHandler( mainINTERRUPT_NUMBER, ulEventBitSettingISR );
 
@@ -773,7 +773,7 @@ state and executes immediately every time any of the event bits are set.
 <a name="fig9.3" title="Figure 9.3 The output produced when Example 9.1 is executed with xWaitForAllBits set to pdFALSE"></a>
 
 * * *
-![](media/image73.jpg)   
+![](media/image73.jpg)
 ***Figure 9.3*** *The output produced when Example 9.1 is executed with xWaitForAllBits set to pdFALSE*
 * * *
 
@@ -788,7 +788,7 @@ event bits are set.
 <a name="fig9.4" title="Figure 9.4 The output produced when Example 9.1 is executed with xWaitForAllBits set to pdTRUE"></a>
 
 * * *
-![](media/image74.jpg)   
+![](media/image74.jpg)
 ***Figure 9.4*** *The output produced when Example 9.1 is executed with xWaitForAllBits set to pdTRUE*
 * * *
 
@@ -854,7 +854,7 @@ void SocketTxTask( void *pvParameters )
         {
             if( FreeRTOS_send( xSocket, ... ) < 0 )
             {
-                /* Unexpected error - exit the loop, after which the socket 
+                /* Unexpected error - exit the loop, after which the socket
                    will be closed. */
                 break;
             }
@@ -865,7 +865,7 @@ void SocketTxTask( void *pvParameters )
 
         /* This is the Tx task's synchronization point. The Tx task waits here
            for the Rx task to reach its synchronization point. The Rx task will
-           only reach its synchronization point when it is no longer using the 
+           only reach its synchronization point when it is no longer using the
            socket, and the socket can be closed safely. */
         xEventGroupSync( ... );
 
@@ -898,7 +898,7 @@ void SocketRxTask( void *pvParameters )
         }
 
         /* This is the Rx task's synchronization point - it only reaches here
-           when it is no longer using the socket, and it is therefore safe for 
+           when it is no longer using the socket, and it is therefore safe for
            the Tx task to close the socket. */
         xEventGroupSync( ... );
     }
@@ -1067,17 +1067,17 @@ static void vSyncingTask( void *pvParameters )
                                         mainSECOND_TASK_BIT |
                                         mainTHIRD_TASK_BIT );
 
-    /* Three instances of this task are created - each task uses a different 
-       event bit in the synchronization. The event bit to use is passed into 
-       each task instance using the task parameter. Store it in the 
+    /* Three instances of this task are created - each task uses a different
+       event bit in the synchronization. The event bit to use is passed into
+       each task instance using the task parameter. Store it in the
        uxThisTasksSyncBit variable. */
     uxThisTasksSyncBit = ( EventBits_t ) pvParameters;
 
     for( ;; )
     {
         /* Simulate this task taking some time to perform an action by delaying
-           for a pseudo random time. This prevents all three instances of this 
-           task reaching the synchronization point at the same time, and so 
+           for a pseudo random time. This prevents all three instances of this
+           task reaching the synchronization point at the same time, and so
            allows the example's behavior to be observed more easily. */
         xDelayTime = ( rand() % xMaxDelay ) + xMinDelay;
         vTaskDelay( xDelayTime );
@@ -1096,7 +1096,7 @@ static void vSyncingTask( void *pvParameters )
                             the synchronization point. */
                          uxThisTasksSyncBit,
 
-                         /* The bits to wait for, one bit for each task taking 
+                         /* The bits to wait for, one bit for each task taking
                             part in the synchronization. */
                          uxAllSyncBits,
 
@@ -1105,8 +1105,8 @@ static void vSyncingTask( void *pvParameters )
                          portMAX_DELAY );
 
         /* Print out a message to show this task has passed its synchronization
-           point. As an indefinite delay was used the following line will only 
-           be executed after all the tasks reached their respective 
+           point. As an indefinite delay was used the following line will only
+           be executed after all the tasks reached their respective
            synchronization points. */
         vPrintTwoStrings( pcTaskGetTaskName( NULL ), "exited sync point" );
     }
@@ -1136,7 +1136,7 @@ int main( void )
     xEventGroup = xEventGroupCreate();
 
     /* Create three instances of the task. Each task is given a different
-       name, which is later printed out to give a visual indication of which 
+       name, which is later printed out to give a visual indication of which
        task is executing. The event bit to use when the task reaches its
        synchronization point is passed into the task using the task parameter. */
     xTaskCreate( vSyncingTask, "Task 1", 1000, mainFIRST_TASK_BIT, 1, NULL );
@@ -1168,7 +1168,7 @@ therefore show some timing variation.
 <a name="fig9.5" title="Figure 9.5 The output produced when Example 9.2 is executed"></a>
 
 * * *
-![](media/image75.jpg)   
+![](media/image75.jpg)
 ***Figure 9.5*** *The output produced when Example 9.2 is executed*
 * * *
 

--- a/examples/Win32-simulator-MSVC/Examples/Example022/main.c
+++ b/examples/Win32-simulator-MSVC/Examples/Example022/main.c
@@ -2,12 +2,12 @@
  *  Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  *
  *  SPDX-License-Identifier: MIT-0
- * 
+ *
  *  VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
  *
  *  This file is part of the FreeRTOS distribution.
- * 
- *  This contains the Windows port implementation of the examples listed in the 
+ *
+ *  This contains the Windows port implementation of the examples listed in the
  *  FreeRTOS book Mastering_the_FreeRTOS_Real_Time_Kernel.
  *
  */
@@ -89,7 +89,7 @@ int main( void )
 
 static void vEventBitSettingTask( void * pvParameters )
 {
-    const TickType_t xDelay200ms = pdMS_TO_TICKS( 200UL ), xDontBlock = 0;
+    const TickType_t xDelay200ms = pdMS_TO_TICKS( 200UL );
 
     for( ; ; )
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In Chapter 9, Listing 9.7, there is unused variable
which could be removed. The same example is also
available for the Win32-simulator, so the variable
is removed also from there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
