### PR TITLE
Fixed typo in chapter 10

### DIFF
--- a/ch10.md
+++ b/ch10.md
@@ -1336,7 +1336,7 @@ A schematic of the software design is shown in Figure 10.6. In Figure 10.6:
   queue, and receives the requested data from the server task as a
   task notification.
 
-- Application tasks write date to the cloud server by calling
+- Application tasks write data to the cloud server by calling
   `CloudWrite()`. `CloudWrite()` does not communicate with the cloud
   server directly, but instead sends the write request to the server
   task on a queue, and receives the result of the write operation from


### PR DESCRIPTION
Minor typo fix in Chapter 10.3.9
We"re talking about dat**a** that we can write to the cloud server using `CloudWrite()`

*Description of changes:*

dat**e** -> dat**a**



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

P.s. The book is amazing!