### PR TITLE
Add a missing backtick for pulNotificationValue of xTaskNotifyWait()

### DIFF
--- a/ch10.md
+++ b/ch10.md
@@ -791,7 +791,7 @@ BaseType_t xTaskNotifyWait( uint32_t   ulBitsToClearOnEntry,
   to `*pulNotificationValue` is the task's notification value as it was
   before any bits were cleared due to the `ulBitsToClearOnExit` setting.
 
-  `pulNotificationValue is an optional parameter and can be set to NULL
+  `pulNotificationValue` is an optional parameter and can be set to NULL
   if it is not required.
 
 - `xTicksToWait`


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added a missing closing backtick


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
